### PR TITLE
Add device-activity-monitor ExtensionType

### DIFF
--- a/target-plugin/target.ts
+++ b/target-plugin/target.ts
@@ -20,6 +20,7 @@ export type ExtensionType =
   | "location-push"
   | "credentials-provider"
   | "account-auth"
+  | "device-activity-monitor"
   | "safari";
 
 export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =


### PR DESCRIPTION
The Device Activity Monitor is a very simple extension, so it does not require any additional logic to work.