### PR TITLE
Add device-activity-monitor ExtensionType

### DIFF
--- a/target-plugin/target.ts
+++ b/target-plugin/target.ts
@@ -20,6 +20,7 @@ export type ExtensionType =
   | "location-push"
   | "credentials-provider"
   | "account-auth"
+  | "device-activity-monitor"
   | "safari";
 
 export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =

--- a/target-plugin/target.ts
+++ b/target-plugin/target.ts
@@ -268,6 +268,8 @@ export function getFrameworksForType(type: ExtensionType) {
     return ["QuickLookThumbnailing"];
   } else if (type === "notification-content") {
     return ["UserNotifications", "UserNotificationsUI"];
+  } else if (type === "device-activity-monitor") {
+    return ["DeviceActivity"];
   }
 
   return [];

--- a/targets/device-activity-monitor/ActivityMonitorExtension.entitlements
+++ b/targets/device-activity-monitor/ActivityMonitorExtension.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.family-controls</key>
+	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.ActivityMonitor</string>
+	</array>
+</dict>
+</plist>

--- a/targets/device-activity-monitor/DeviceActivityMonitorExtension.swift
+++ b/targets/device-activity-monitor/DeviceActivityMonitorExtension.swift
@@ -1,0 +1,71 @@
+//
+//  DeviceActivityMonitorExtension.swift
+//  ActivityMonitorExtension
+//
+//  Created by Robert Herber on 2023-07-05.
+//
+
+import DeviceActivity
+import ManagedSettings
+import Foundation
+import os
+
+// Optionally override any of the functions below.
+// Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
+@available(iOS 15.0, *)
+class DeviceActivityMonitorExtension: DeviceActivityMonitor {
+  let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
+  
+  func sendNotification(name: String){
+    let notificationName = CFNotificationName(name as CFString)
+
+     CFNotificationCenterPostNotification(notificationCenter, notificationName, nil, nil, false)
+  }
+  
+    override func intervalDidStart(for activity: DeviceActivityName) {
+      super.intervalDidStart(for: activity)
+      
+      self.sendNotification(name: "intervalDidStart")
+    }
+    
+    override func intervalDidEnd(for activity: DeviceActivityName) {
+      super.intervalDidEnd(for: activity)
+      
+
+      self.sendNotification(name: "intervalDidEnd")
+    }
+    
+    override func eventDidReachThreshold(_ event: DeviceActivityEvent.Name, activity: DeviceActivityName) {
+      super.eventDidReachThreshold(event, activity: activity)
+      
+      let userDefaults = UserDefaults(suiteName: "group.ActivityMonitor")
+      let now = (Date().timeIntervalSince1970 * 1000).rounded()
+      userDefaults?.set(now, forKey: "activity_event_last_called_\(event.rawValue)")
+      
+      let notificationName = CFNotificationName("com.notification.name" as CFString)
+      let notificationCenter = CFNotificationCenterGetDarwinNotifyCenter()
+
+      CFNotificationCenterPostNotification(notificationCenter, notificationName, nil, nil, false)
+        
+      self.sendNotification(name: "eventDidReachThreshold")
+    }
+    
+    override func intervalWillStartWarning(for activity: DeviceActivityName) {
+      super.intervalWillStartWarning(for: activity)
+        
+      self.sendNotification(name: "intervalWillStartWarning")
+    }
+    
+    override func intervalWillEndWarning(for activity: DeviceActivityName) {
+      super.intervalWillEndWarning(for: activity)
+        
+      self.sendNotification(name: "intervalWillEndWarning")
+    }
+    
+    override func eventWillReachThresholdWarning(_ event: DeviceActivityEvent.Name, activity: DeviceActivityName) {
+      super.eventWillReachThresholdWarning(event, activity: activity)
+      
+      self.sendNotification(name: "eventWillReachThresholdWarning")
+    }
+  
+}

--- a/targets/device-activity-monitor/Info.plist
+++ b/targets/device-activity-monitor/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.deviceactivity.monitor-extension</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).DeviceActivityMonitorExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/targets/device-activity-monitor/expo-target.config.json
+++ b/targets/device-activity-monitor/expo-target.config.json
@@ -1,0 +1,6 @@
+
+{
+  "type": "device-activity-monitor",
+  "deploymentTarget": "15.0",
+  "frameworks": ["DeviceActivity"]
+}

--- a/targets/device-activity-monitor/expo-target.config.json
+++ b/targets/device-activity-monitor/expo-target.config.json
@@ -1,6 +1,4 @@
 
 {
-  "type": "device-activity-monitor",
-  "deploymentTarget": "15.0",
-  "frameworks": ["DeviceActivity"]
+  "type": "device-activity-monitor"
 }


### PR DESCRIPTION
The Device Activity Monitor is a very simple extension. Adding the DeviceActivity.framework to reduce boilerplate. Also added an example in the targets folder.

One question - since I'm planning to use this inside a package and publish it. Is there a way to configure the Info.plist with a config plugin? Would be nice to make the Application Group configurable.