### PR TITLE
add AppIntent ExtensionType

### DIFF
--- a/target-plugin/target.ts
+++ b/target-plugin/target.ts
@@ -20,7 +20,8 @@ export type ExtensionType =
   | "location-push"
   | "credentials-provider"
   | "account-auth"
-  | "safari";
+  | "safari"
+  | "appintent";
 
 export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =
   {
@@ -41,6 +42,7 @@ export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =
       "credentials-provider",
     "com.apple.authentication-services-account-authentication-modification-ui":
       "account-auth",
+    "com.apple.appintents-extension": "appintent",
     // "com.apple.intents-service": "intents",
   };
 
@@ -216,6 +218,12 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
         NSExtensionPointIdentifier,
       },
     });
+  } else if (type === "appintent") {
+    return plist.build({
+      EXAppExtensionAttributes: {
+        EXExtensionPointIdentifier: NSExtensionPointIdentifier,
+      },
+    });
   }
 
   // Default: used for widget and bg-download
@@ -232,6 +240,8 @@ export function productTypeForType(type: ExtensionType) {
       return "com.apple.product-type.application.on-demand-install-capable";
     case "watch":
       return "com.apple.product-type.application";
+    case "appintent":
+      return "com.apple.product-type.extensionkit-extension";
     default:
       return "com.apple.product-type.app-extension";
   }
@@ -267,6 +277,8 @@ export function getFrameworksForType(type: ExtensionType) {
     return ["QuickLookThumbnailing"];
   } else if (type === "notification-content") {
     return ["UserNotifications", "UserNotificationsUI"];
+  } else if (type === "appintent") {
+    return ["AppIntents"];
   }
 
   return [];

--- a/targets/appintent/Info.plist
+++ b/targets/appintent/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EXAppExtensionAttributes</key>
+	<dict>
+		<key>EXExtensionPointIdentifier</key>
+		<string>com.apple.appintents-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/targets/appintent/appintent.swift
+++ b/targets/appintent/appintent.swift
@@ -1,0 +1,16 @@
+import AppIntents
+
+
+// Optionally override any of the functions below.
+// Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
+@available(iOS 16.0, *)
+struct AppIntentExample: AppIntent {
+  static var title: LocalizedStringResource = "My App Intent"
+
+  static var openAppWhenRun: Bool = true
+
+  @MainActor
+  func perform() async throws -> some ProvidesDialog {
+    return .result(dialog: "Example App Intent response")
+  }
+}

--- a/targets/appintent/expo-target.config.js
+++ b/targets/appintent/expo-target.config.js
@@ -1,0 +1,4 @@
+/** @type {import('../../../target-plugin/src/config').Config} */
+module.exports = {
+  type: "appintent",
+};


### PR DESCRIPTION
This extension adds support for [iOS AppIntents](https://developer.apple.com/documentation/appintents). This is a new way for creating Shortcuts via the App Intent Framework introduced in iOS 16. It kind of replaces the older siri app intent target: https://developer.apple.com/documentation/widgetkit/migrating-from-sirikit-intents-to-app-intents

Also added an example app intent folder.