### PR TITLE
feat: include top-level storyboard files

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -15,7 +15,7 @@ An experimental Expo Config Plugin that generates native Apple Targets like Widg
 - Currently, if you don't have an `Info.plist`, it'll be generated on `npx expo prebuild`. This may be changed in the future so if you have an `Info.plist` it'll be used, otherwise, it'll be generated.
 - Any files in a top-level `target/*/assets` directory will be linked as resources of the target. This was added to support Safari Extensions.
 - A single top-level `*.entitlements` file will be linked as the entitlements of the target. This is not currently used in EAS Capability signing, but may be in the future.
-- All top-level swift files will be linked as build sources of the target. There is currently no support for storyboard or `.xib` files because I can't be bothered.
+- All top-level swift files will be linked as build sources of the target. There is currently no support for `.xib` files because I can't be bothered.
 - All top-level `*.xcassets` will be linked as resources, and accessible in the targets. If you add files outside of Xcode, you'll need to re-run `npx expo prebuild` to link them.
 - Code-signing requires the teamId be provided to the plugin in `app.config.js`.
 

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -1017,6 +1017,24 @@ async function applyXcodeChanges(
     })
   );
 
+  // NOTE: Single-level only
+  const storyboardFiles = globSync("*.storyboard", {
+    absolute: true,
+    cwd: magicCwd,
+  }).map((file) => {
+    return PBXFileReference.create(project, {
+      lastKnownFileType: "file.storyboard",
+      path: path.basename(file),
+      sourceTree: "<group>",
+    });
+  });
+
+  const storyBoardBuildFiles = storyboardFiles.map((file) => {
+    return PBXBuildFile.create(project, {
+      fileRef: file,
+    });
+  });
+
   let assetFiles = [
     // All assets`
     // "assets/*",
@@ -1131,7 +1149,7 @@ async function applyXcodeChanges(
   });
 
   widgetTarget.createBuildPhase(PBXResourcesBuildPhase, {
-    files: [...assetFiles, ...resAssets],
+    files: [...storyBoardBuildFiles, ...assetFiles, ...resAssets],
   });
   const containerItemProxy = PBXContainerItemProxy.create(project, {
     containerPortal: project.rootObject,
@@ -1211,6 +1229,11 @@ async function applyXcodeChanges(
       ...intentFiles.sort((a, b) =>
         a.getDisplayName().localeCompare(b.getDisplayName())
       ),
+
+      // @ts-expect-error
+      ...storyBoardBuildFiles
+        .map((buildFile) => buildFile.props.fileRef)
+        .sort((a, b) => a.getDisplayName().localeCompare(b.getDisplayName())),
 
       // @ts-expect-error
       ...assetFiles


### PR DESCRIPTION
Adds support for top-level storyboard files.

### How to test the changes

- Place a new Storyboard file into one of the targets, e.g. the `watch-app` target, e.g.:
**Storyboard.storyboard**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="22155" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="IGi-cB-aGO">
    <device id="watch38"/>
    <dependencies>
        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="22022"/>
    </dependencies>
    <scenes>
        <!--MainController-->
        <scene sceneID="fRD-1l-P1O">
            <objects>
                <controller identifier="MainController" id="IGi-cB-aGO" customClass="MainController" customModule="WatchApp_Watch_App" customModuleProvider="target"/>
            </objects>
            <point key="canvasLocation" x="-148" y="-118"/>
        </scene>
    </scenes>
</document>
```
- Delete the iOS folder
- Run `yarn prepare` in the top level to generate the config plugin
- Run `yarn nprebuild` to regenerate the iOS project
- Open the iOS project

-> You should now see the storyboard being correctly linked in the watch app target
![CleanShot 2023-12-12 at 18 50 42](https://github.com/EvanBacon/expo-apple-targets/assets/16821682/8762b67d-865f-4f37-85f8-9fadcca1e978)
