### PR TITLE
feat: add dependencyTargets

### DIFF
--- a/packages/apple-targets/src/config.ts
+++ b/packages/apple-targets/src/config.ts
@@ -102,6 +102,13 @@ export type Config = {
    */
   frameworks?: string[];
 
+  /**
+   * A list of additional extensions to add to the target (possibly from other targets, so match the name of the target),
+   * without the .appex extension.
+   * @example ["myWidgetExtension"]
+   */
+  dependencyTargets?: string[];
+
   /** Deployment iOS version for the target. Defaults to `16.4` */
   deploymentTarget?: string;
 

--- a/packages/apple-targets/src/index.ts
+++ b/packages/apple-targets/src/index.ts
@@ -3,8 +3,38 @@ import { sync as globSync } from "glob";
 import path from "path";
 
 import type { Config } from "./config";
-import withWidget from "./withWidget";
+import withWidget, { Props } from "./withWidget";
 import { withXcodeProjectBetaBaseMod } from "./withXcparse";
+
+// A target can depend on another target using the `dependencyTargets` property.
+// Therefor, we need to execute the targets in the right order.
+const sortTargetProps = (configs: Props[]) => {
+  const targetMap = new Map();
+  configs.forEach((target) => targetMap.set(target.name, target));
+
+  const visited = new Set();
+  const sorted: Props[] = [];
+
+  function visit(config: Props) {
+    if (visited.has(config.name)) {
+      return;
+    }
+    visited.add(config.name);
+
+    if (config.dependencyTargets) {
+      config.dependencyTargets.forEach((depName) => {
+        if (targetMap.has(depName)) {
+          visit(targetMap.get(depName));
+        }
+      });
+    }
+
+    sorted.push(config);
+  }
+
+  configs.forEach((target) => visit(target));
+  return sorted;
+};
 
 export const withTargetsDir: ConfigPlugin<{
   appleTeamId: string;
@@ -22,12 +52,21 @@ export const withTargetsDir: ConfigPlugin<{
     absolute: true,
   });
 
-  targets.forEach((configPath) => {
-    config = withWidget(config, {
-      appleTeamId,
-      ...require(configPath),
-      directory: path.relative(projectRoot, path.dirname(configPath)),
-    });
+  const targetProps = targets.map((configPath) => ({
+    appleTeamId,
+    ...require(configPath),
+    directory: path.relative(projectRoot, path.dirname(configPath)),
+  }));
+
+  const sortedTargetProps = sortTargetProps(targetProps);
+
+  // Now we need to reverse the targets order. Thats because we will call withMod consecutively.
+  // When we call withMod#1 then withMod#2, the execution order of the mods will be withMod#2 then withMod#1.
+  // Thus we have to reverse …
+  sortedTargetProps.reverse();
+
+  sortedTargetProps.forEach((targetConfig) => {
+    config = withWidget(config, targetConfig);
   });
 
   return withXcodeProjectBetaBaseMod(config);

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -12,7 +12,7 @@ import { getFrameworksForType, getTargetInfoPlistForType } from "./target";
 import { withEASTargets } from "./withEasCredentials";
 import { withXcodeChanges } from "./withXcodeChanges";
 
-type Props = Config & {
+export type Props = Config & {
   directory: string;
 };
 
@@ -140,6 +140,7 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
     currentProjectVersion: config.ios?.buildNumber || 1,
 
     frameworks: getFrameworksForType(props.type).concat(props.frameworks || []),
+    dependencyTargets: props.dependencyTargets || [],
     type: props.type,
     teamId: props.appleTeamId,
   });


### PR DESCRIPTION
Sometimes one target needs to embedded to another target, not directly to the main app.

To achieve that the order in which we add the targets to the project is important. Thus we first need to order the tasks, so they get added in the right order in case one target has a dependency on another one.

(Note: for that to work correctly it was important to make the `withXcodeProjectBeta`/`applyXcodeChanges` actually await so they get executed after one another (which seems to be related to the intrinsics of withBaseMod).

With this, its possible to do this:

```js
// targets/watch-app/expo-target.config.js
module.exports = {
  type: "watch",
  // ⬇️ New: Depend on another target
  dependencyTargets: ["watchcomplication"],
};
```

```js
// targets/watch-complication/expo-target.config.js
module.exports = {
  type: "widget",
  name: "watchcomplication"
};
```

I am implementing this aiming to support watch complication widget extensions. It sill needs a bit more work, but this is a PR for that.
Partly addresses: #6