### PR TITLE
feat: add support for custom bundle identifier

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -3,11 +3,9 @@
 > [!WARNING]
 > This is highly experimental and not part of any official Expo workflow.
 
-
 <img width="1061" alt="Screenshot 2023-06-10 at 1 59 26 PM" src="https://github.com/EvanBacon/expo-apple-targets/assets/9664363/4cd8399d-53aa-401a-9caa-3a1432a0640c">
 
 An experimental Expo Config Plugin that generates native Apple Targets like Widgets or App Clips, and links them outside the `/ios` directory. You can open Xcode and develop the targets inside the virtual `expo:targets` folder and the changes will be saved outside of the `ios` directory. This pattern enables building things that fall outside of the scope of React Native while still obtaining all the benefits of Continuous Native Generation.
-
 
 ## 🚀 How to use
 
@@ -69,7 +67,11 @@ This file can have the following properties:
   },
 
   // The iOS version fot the target.
-  "deploymentTarget": "13.4"
+  "deploymentTarget": "13.4",
+
+  // Optional bundle identifier for the target. Will default to a sanitized version of the root project bundle id + target name.
+  // If the specified bundle identifier is prefixed with a dot (.), the bundle identifier will be appended to the main app's bundle identifier.
+  "bundleIdentifier": ".mywidget"
 }
 ```
 

--- a/packages/apple-targets/src/config.ts
+++ b/packages/apple-targets/src/config.ts
@@ -87,8 +87,16 @@ export type Config = {
    * @example "widget"
    */
   type: ExtensionType;
+
   /** Name of the target. Will default to a sanitized version of the directory name. */
   name?: string;
+
+  /**
+   * Bundle identifier for the target. Will default to a sanitized version of the root project + name.
+   * If the specified bundle identifier is prefixed with a dot (.), the bundle identifier will be appended to the main app's bundle identifier.
+   **/
+  bundleIdentifier?: string;
+
   /**
    * A local file path or URL to an image asset.
    * @example "./assets/icon.png"

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -120,7 +120,10 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
   ]);
 
   const targetName = props.name ?? widget;
-  const bundleId = config.ios!.bundleIdentifier! + "." + widget;
+  const mainAppBundleId = config.ios!.bundleIdentifier!;
+  const bundleId = props.bundleIdentifier?.startsWith(".")
+    ? mainAppBundleId + props.bundleIdentifier
+    : props.bundleIdentifier ?? `${mainAppBundleId}.${targetName}`;
 
   withXcodeChanges(config, {
     name: targetName,


### PR DESCRIPTION
If we want to add for example a watch os widget extension to a watch target, it needs to start with same bundle id as the watch target. This gives the possibility to customise it.

Either pass a full bundle identifier, or start with a dot (.) so it will get appended to the main apps bundle id.