### PR TITLE
feat: add `embedInApp` flag

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -3,11 +3,9 @@
 > [!WARNING]
 > This is highly experimental and not part of any official Expo workflow.
 
-
 <img width="1061" alt="Screenshot 2023-06-10 at 1 59 26 PM" src="https://github.com/EvanBacon/expo-apple-targets/assets/9664363/4cd8399d-53aa-401a-9caa-3a1432a0640c">
 
 An experimental Expo Config Plugin that generates native Apple Targets like Widgets or App Clips, and links them outside the `/ios` directory. You can open Xcode and develop the targets inside the virtual `expo:targets` folder and the changes will be saved outside of the `ios` directory. This pattern enables building things that fall outside of the scope of React Native while still obtaining all the benefits of Continuous Native Generation.
-
 
 ## 🚀 How to use
 
@@ -69,7 +67,10 @@ This file can have the following properties:
   },
 
   // The iOS version fot the target.
-  "deploymentTarget": "13.4"
+  "deploymentTarget": "13.4",
+
+  // Default is true. When true it will embed the target in the app (this is very likely what you want).
+  "embedInApp": true
 }
 ```
 

--- a/packages/apple-targets/src/config.ts
+++ b/packages/apple-targets/src/config.ts
@@ -111,6 +111,9 @@ export type Config = {
   /** Optional entitlements to add to the target. */
   entitlements?: Entitlements;
 
+  /** Default true. When true it will embed the target in the main app. */
+  embedInApp?: boolean;
+
   /**
    * Additional colors to generate in the `Assets.xcassets`. These will be available as `UIColor`s in the native source.
    * @example In Expo config: `colors: { gradient1: { color: "#FF0000", darkColor: "#0000FF" }`

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -136,6 +136,8 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
 
     hasAccentColor: !!props.colors?.$accent,
 
+    embedInApp: props.embedInApp ?? true,
+
     // @ts-expect-error: who cares
     currentProjectVersion: config.ios?.buildNumber || 1,
 

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -28,6 +28,7 @@ import {
   productTypeForType,
 } from "./target";
 import fixture from "./template/XCBuildConfiguration.json";
+import { withXcodeProjectBeta } from "./withXcparse";
 const TemplateBuildSettings = fixture as unknown as Record<
   string,
   {
@@ -37,7 +38,6 @@ const TemplateBuildSettings = fixture as unknown as Record<
     info: any;
   }
 >;
-import { withXcodeProjectBeta } from "./withXcparse";
 
 export type XcodeSettings = {
   name: string;
@@ -56,6 +56,8 @@ export type XcodeSettings = {
   type: ExtensionType;
 
   hasAccentColor?: boolean;
+
+  embedInApp: boolean;
 
   colors?: Record<string, string>;
 
@@ -1140,13 +1142,15 @@ async function applyXcodeChanges(
     remoteInfo: productName,
   });
 
-  const targetDependency = PBXTargetDependency.create(project, {
-    target: widgetTarget,
-    targetProxy: containerItemProxy,
-  });
+  if (props.embedInApp) {
+    const targetDependency = PBXTargetDependency.create(project, {
+      target: widgetTarget,
+      targetProxy: containerItemProxy,
+    });
 
-  // Add the target dependency to the main app, should be only one.
-  mainAppTarget.props.dependencies.push(targetDependency);
+    // Add the target dependency to the main app, should be only one.
+    mainAppTarget.props.dependencies.push(targetDependency);
+  }
 
   const WELL_KNOWN_COPY_EXTENSIONS_NAME =
     props.type === "clip"
@@ -1162,10 +1166,10 @@ async function applyXcodeChanges(
     }
   });
 
-  if (copyFilesBuildPhase) {
+  if (copyFilesBuildPhase && props.embedInApp) {
     // Assume that this is the first run if there is no matching target that we identified from a previous run.
     copyFilesBuildPhase.props.files.push(alphaExtensionAppexBf);
-  } else {
+  } else if (props.embedInApp) {
     const dstPath = (
       { clip: "AppClips", watch: "Watch" } as Record<string, string>
     )[props.type];


### PR DESCRIPTION
By default all targets get added as extension to the main app. In case where we have a widget extension for a watch target, that might be undesirable. It should only be embedded for the watch target, but not for the main app.