### PR TITLE
Take widget from name props

### DIFF
--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -29,7 +29,7 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
     props.icon = path.join(props.directory, props.icon);
   }
 
-  const widgetDir = path
+  const widgetDir = props.name || path
     .basename(props.directory)
     .replace(/\/+$/, "")
     .replace(/^\/+/, "");


### PR DESCRIPTION
If `expo-target.config.js` file is not in `targets/widgets`, and for example in `targets/widgets/ios` **Bundle Identifier** for widget  will be like `com.org.ios`. To avoid that I propose to get that param from name prop.