### PR TITLE
xcode peculiarities

### DIFF
--- a/packages/apple-targets/src/template/XCBuildConfiguration.json
+++ b/packages/apple-targets/src/template/XCBuildConfiguration.json
@@ -25,7 +25,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -76,7 +76,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -122,7 +122,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -168,7 +168,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -214,7 +214,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -260,7 +260,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -310,7 +310,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -359,7 +359,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -408,7 +408,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -465,7 +465,7 @@
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
       "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -514,7 +514,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -568,7 +568,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -619,7 +619,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -672,7 +672,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {
@@ -720,7 +720,7 @@
       "PRODUCT_NAME": "$(TARGET_NAME)",
       "SKIP_INSTALL": "YES",
       "SWIFT_EMIT_LOC_STRINGS": "YES",
-      "SWIFT_VERSION": 5,
+      "SWIFT_VERSION": "5.0",
       "TARGETED_DEVICE_FAMILY": "1,2"
     },
     "release": {


### PR DESCRIPTION
Xcode seems to think that `5` and `5.0` are different swift versions, and the default is for Xcode to use `5.0`, so I'm updating the template here, so that extension targets use `5.0` and make Xcode happy.