### PR TITLE
EAS appExtensions overwritten and only one target being added

### DIFF
--- a/packages/apple-targets/src/withEasCredentials.ts
+++ b/packages/apple-targets/src/withEasCredentials.ts
@@ -14,7 +14,9 @@ function safeSet(obj: any, key: string, value: any) {
     }
     obj = obj[segment];
   });
-  obj[last!] = value;
+  if (!obj[last!]) {
+    obj[last!] = value;
+  }
 
   return obj;
 }


### PR DESCRIPTION
If we add more than one target, only the last target is added to `extra.eas.build.experimental.ios.appExtensions`. Furthermore, any entries in `extra.eas.build.experimental.ios.appExtensions` are being overwritten rather than being extended.

Looking at the rest of the code in `withEASTargets`, it expects other entries and will merge/update them.

This PR will make it work as intended.

If anyone is facing this exact issue, you can patch the package, until @EvanBacon merges and release a new version.