### PR TITLE
feat: ✨ add `displayName` config option

### DIFF
--- a/packages/apple-targets/src/config.ts
+++ b/packages/apple-targets/src/config.ts
@@ -90,6 +90,12 @@ export type Config = {
   type: ExtensionType;
   /** Name of the target. Will default to a sanitized version of the directory name. */
   name?: string;
+
+  /**
+   * The display name of the widget.
+   * @example "My Widget"
+   */
+  displayName?: string;
   /**
    * A local file path or URL to an image asset.
    * @example "./assets/icon.png"

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -143,6 +143,7 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
 
   const targetName = props.name ?? widget;
   const bundleId = config.ios!.bundleIdentifier! + "." + widget;
+  const displayName = props.displayName ?? widget;
 
   withXcodeChanges(config, {
     name: targetName,
@@ -154,6 +155,7 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
       ),
     deploymentTarget: props.deploymentTarget ?? "16.4",
     bundleId,
+    displayName,
     icon: props.icon,
 
     hasAccentColor: !!props.colors?.$accent,

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -49,6 +49,8 @@ export type XcodeSettings = {
   bundleId: string;
   // 16.4
   deploymentTarget: string;
+  /** The display name of the widget. */
+  displayName: string;
 
   // 1
   currentProjectVersion: number;
@@ -628,6 +630,7 @@ function createConfigurationList(
   project: XcodeProject,
   {
     name,
+    displayName,
     cwd,
     bundleId,
     deploymentTarget,
@@ -652,7 +655,7 @@ function createConfigurationList(
       GCC_C_LANGUAGE_STANDARD: "gnu11",
       GENERATE_INFOPLIST_FILE: "YES",
       INFOPLIST_FILE: cwd + "/Info.plist",
-      INFOPLIST_KEY_CFBundleDisplayName: name,
+      INFOPLIST_KEY_CFBundleDisplayName: displayName,
       INFOPLIST_KEY_NSHumanReadableCopyright: "",
       IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
       LD_RUNPATH_SEARCH_PATHS:
@@ -690,7 +693,7 @@ function createConfigurationList(
       GCC_C_LANGUAGE_STANDARD: "gnu11",
       GENERATE_INFOPLIST_FILE: "YES",
       INFOPLIST_FILE: cwd + "/Info.plist",
-      INFOPLIST_KEY_CFBundleDisplayName: name,
+      INFOPLIST_KEY_CFBundleDisplayName: displayName,
       INFOPLIST_KEY_NSHumanReadableCopyright: "",
       IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
       LD_RUNPATH_SEARCH_PATHS:


### PR DESCRIPTION
This PR adds a new config option called `displayName` to specify a different display name if desired. Does not break any existing functionalities.