### PR TITLE
Use default asset file type instead of text

### DIFF
--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -1214,7 +1214,7 @@ async function applyXcodeChanges(
                 ? "text.html"
                 : file.endsWith(".css")
                 ? "text.css"
-                : "text",
+                : undefined,
               sourceTree: "<group>",
             }),
           })


### PR DESCRIPTION
Instead of falling back to "text" asset file type, let Xcode decide.
This fixes font embedding for me in a Live Activity target.

<img width="48%" alt="Screenshot 2024-11-18 at 12 58 56" src="https://github.com/user-attachments/assets/9b013737-83b5-40b4-8817-8326cad49d89">
<img width="48%" alt="Screenshot 2024-11-18 at 12 59 46" src="https://github.com/user-attachments/assets/f8ffd3ac-5a8c-4e85-9b9d-b91587581cca">
