### PR TITLE
feat: app clip improvements

### DIFF
--- a/apps/app-clip-demo/targets/clip/expo-target.config.js
+++ b/apps/app-clip-demo/targets/clip/expo-target.config.js
@@ -1,6 +1,9 @@
 /** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
-module.exports = config => ({
+module.exports = (config) => ({
   type: "clip",
-  icon: 'https://github.com/expo.png',
-  entitlements: { /* Add entitlements */ },
+  name: "Complex Name",
+  icon: "https://github.com/expo.png",
+  entitlements: {
+    /* Add entitlements */
+  },
 });

--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -491,3 +491,5 @@ You should also add the `og:image` property using `expo-router/head`. [Learn mor
 You also need a `1800x1200` image for the App Store Connect image preview, so make both of these images around the same time.
 
 Launch App Clips from Test Flight to test deep linking. It doesn't seem like there's any reasonable way to test launching from your website in development. I got this to work once by setting up a local experience in my app's "Settings > Developer" screen, then installing the app, opening the website, deleting the app, then installing the App Clip without the app. You'll mostly need to go with God on this one.
+
+You can generate codes using the CLI tool [download here](https://developer.apple.com/download/all/?q=%22app%20clip%22).

--- a/packages/apple-targets/src/config.ts
+++ b/packages/apple-targets/src/config.ts
@@ -80,6 +80,7 @@ export type Entitlements = Partial<{
   "com.apple.developer.driverkit.transport.hid": boolean;
   "com.apple.developer.driverkit.family.audio": boolean;
   "com.apple.developer.shared-with-you": boolean;
+  "com.apple.developer.associated-domains": string[];
 }>;
 
 export type Config = {

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -316,7 +316,12 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
   const bundleId = props.bundleIdentifier?.startsWith(".")
     ? mainAppBundleId + props.bundleIdentifier
     : props.bundleIdentifier ??
-      `${mainAppBundleId}.${getSanitizedBundleIdentifier(targetName)}`;
+      `${mainAppBundleId}.${
+        props.type === "clip"
+          ? // Use a more standardized bundle identifier for App Clips.
+            "clip"
+          : getSanitizedBundleIdentifier(targetName)
+      }`;
 
   const deviceFamilies: DeviceFamily[] = config.ios?.isTabletOnly
     ? ["tablet"]

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -132,7 +132,7 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
               chalk`{yellow [${widget}]} Apple App Clip may require the associated domains entitlement but none were found in the Expo config.\nExample:\n${JSON.stringify(
                 {
                   ios: {
-                    associatedDomains: ["applinks:myproject.expo.app"],
+                    associatedDomains: [`applinks:placeholder.expo.app`],
                   },
                 },
                 null,
@@ -164,7 +164,7 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
 
             if (unique.length) {
               warnOnce(
-                chalk`{yellow [${widget}]} Apple App Clip missing associated domains entitlements in the target config.\nExample:\n${JSON.stringify(
+                chalk`{gray [${widget}]} Apple App Clip expo-target.config.js missing associated domains entitlements in the target config. Using the following defaults:\n${JSON.stringify(
                   {
                     entitlements: {
                       [associatedDomainsKey]: [

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -15,7 +15,7 @@ import {
   SHOULD_USE_APP_GROUPS_BY_DEFAULT,
 } from "./target";
 import { withEASTargets } from "./withEasCredentials";
-import { withXcodeChanges } from "./withXcodeChanges";
+import { DeviceFamily, withXcodeChanges } from "./withXcodeChanges";
 
 type Props = Config & {
   directory: string;
@@ -318,6 +318,12 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
     : props.bundleIdentifier ??
       `${mainAppBundleId}.${getSanitizedBundleIdentifier(targetName)}`;
 
+  const deviceFamilies: DeviceFamily[] = config.ios?.isTabletOnly
+    ? ["tablet"]
+    : config.ios?.supportsTablet
+    ? ["phone", "tablet"]
+    : ["phone"];
+
   withXcodeChanges(config, {
     configPath: props.configPath,
     name: targetName,
@@ -331,7 +337,10 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
     bundleId,
     icon: props.icon,
 
+    orientation: config.orientation,
     hasAccentColor: !!props.colors?.$accent,
+
+    deviceFamilies,
 
     // @ts-expect-error: who cares
     currentProjectVersion: config.ios?.buildNumber || 1,

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -68,7 +68,13 @@ export type XcodeSettings = {
 
   /** File path to the extension config file. */
   configPath: string;
+
+  orientation?: "default" | "portrait" | "landscape";
+
+  deviceFamilies?: DeviceFamily[];
 };
+
+export type DeviceFamily = "phone" | "tablet";
 
 export const withXcodeChanges: ConfigPlugin<XcodeSettings> = (
   config,
@@ -616,6 +622,8 @@ function createAppClipConfigurationList(
     deploymentTarget,
     currentProjectVersion,
     hasAccentColor,
+    orientation,
+    deviceFamilies,
   }: XcodeSettings
 ) {
   // TODO: Unify AppIcon and AccentColor logic
@@ -651,7 +659,7 @@ function createAppClipConfigurationList(
     PRODUCT_NAME: "$(TARGET_NAME)",
     SWIFT_EMIT_LOC_STRINGS: "YES",
     SWIFT_VERSION: "5.0",
-    TARGETED_DEVICE_FAMILY: "1,2",
+    ...getDeviceFamilyBuildSettings(deviceFamilies),
   };
 
   const infoPlist: Partial<BuildSettings> = {
@@ -659,10 +667,7 @@ function createAppClipConfigurationList(
     INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES",
     INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: "YES",
     INFOPLIST_KEY_UILaunchScreen_Generation: "YES",
-    INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
-      "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight",
-    INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone:
-      "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight",
+    ...getOrientationBuildSettings(orientation),
   };
 
   // @ts-expect-error
@@ -709,6 +714,56 @@ function createAppClipConfigurationList(
   });
 
   return configurationList;
+}
+
+function getOrientationBuildSettings(
+  orientation?: "default" | "portrait" | "landscape"
+) {
+  // Try to align the orientation with the main app.
+  if (orientation === "landscape") {
+    return {
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone:
+        "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight",
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+        "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight",
+    };
+  } else if (orientation === "portrait") {
+    return {
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone:
+        "UIInterfaceOrientationPortrait",
+      INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+        "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown",
+    };
+  }
+
+  return {
+    INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone:
+      "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight",
+    INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+      "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight",
+  };
+}
+
+function getDeviceFamilyBuildSettings(
+  deviceFamilies?: DeviceFamily[]
+): Partial<BuildSettings> {
+  if (!deviceFamilies) {
+    return {
+      TARGETED_DEVICE_FAMILY: "1,2",
+    };
+  }
+
+  const families: number[] = [];
+  if (deviceFamilies.includes("phone")) {
+    families.push(1);
+  }
+  if (deviceFamilies.includes("tablet")) {
+    families.push(2);
+  }
+
+  return {
+    TARGETED_DEVICE_FAMILY: families.join(","),
+  };
 }
 
 function createConfigurationList(
@@ -829,6 +884,9 @@ function createConfigurationListForType(
   } else if (props.type === "imessage") {
     return createIMessageConfigurationList(project, props);
   } else if (props.type === "clip") {
+    // TODO: Set the device orientation to match the full app using:
+    // INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+    // INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
     return createAppClipConfigurationList(project, props);
   } else if (props.type === "watch") {
     return createWatchAppConfigurationList(project, props);

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -884,9 +884,6 @@ function createConfigurationListForType(
   } else if (props.type === "imessage") {
     return createIMessageConfigurationList(project, props);
   } else if (props.type === "clip") {
-    // TODO: Set the device orientation to match the full app using:
-    // INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
-    // INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
     return createAppClipConfigurationList(project, props);
   } else if (props.type === "watch") {
     return createWatchAppConfigurationList(project, props);

--- a/packages/create-target/templates/clip/AppDelegate.swift
+++ b/packages/create-target/templates/clip/AppDelegate.swift
@@ -30,11 +30,11 @@ class AppDelegate: EXAppDelegateWrapper {
   // Linking API
   override func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([any UIUserActivityRestoring]?) -> Void) -> Bool {
     let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler);
-    return super.application(application, continue: userActivity, restorationHandler: restorationHandler);
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result;
   }
   
   override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-    return super.application(app, open: url, options: options)
+    return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
   }
   
 }

--- a/packages/create-target/templates/clip/pods.rb
+++ b/packages/create-target/templates/clip/pods.rb
@@ -1,6 +1,9 @@
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 
-exclude = []
+exclude = [
+  # Bug in Expo Updates preventing it from working with App Clips.
+  "expo-updates"
+]
 use_expo_modules!(exclude: exclude)
 
 if ENV['EXPO_USE_COMMUNITY_AUTOLINKING'] == '1'


### PR DESCRIPTION
I recently built an App Clip with Expo and wanted to streamline more of the process.

- Match the orientations and device families with the main app.
- Warn about missing associated domains entitlements.
- Fix the template AppDelegate for deep linking.
- Prevent linking expo-updates by default.
- Related https://github.com/expo/expo/pull/34327