### PR TITLE
feat: Support better names

### DIFF
--- a/apps/widget-demo/ios/widgetclipdemo.xcodeproj/project.pbxproj
+++ b/apps/widget-demo/ios/widgetclipdemo.xcodeproj/project.pbxproj
@@ -13,19 +13,21 @@
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
 		96905EF65AED1B983A6B3ABC /* libPods-widgetclipdemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 58EEBF8E8E6FB1BC6CAF49B5 /* libPods-widgetclipdemo.a */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
-		E6C3D77E52EF4AFD83620E01 /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C1CD997CFDA4909B454B1F5 /* noop-file.swift */; };
-		XX09E725E164C2787243F7XX /* widget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = XXD26DB380DB6D7349BA89XX /* widget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		C0E950667BAB45379268CF3B /* noop-file.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4884E59A2FBB4A9FA3260962 /* noop-file.swift */; };
 		XX12B55A1EDABF083C3B51XX /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = XX470101BAEB8E0BBC8B0DXX /* WidgetKit.framework */; };
+		XX1A6800511A685AB346D2XX /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = XXA12889081EB894481655XX /* AppIntents.framework */; };
+		XX3C562DEF346B45594832XX /* ActivityKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = XXCAF23C3FC41F82140FA1XX /* ActivityKit.framework */; };
+		XX6357A9A9DEDF49BD6081XX /* My Widget 😄.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = XXBF185C77F1BAFCE93861XX /* My Widget 😄.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		XX6A44985675A04437B8C4XX /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = XX4DFF38D47332D6BF0183XX /* SwiftUI.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		XX214904F50ADE23A58C77XX /* PBXContainerItemProxy */ = {
+		XXA64E64FBB5E0BCCD0762XX /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 83CBB9F71A601CBA00E9B192 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = XX6A0644B8C84798435039XX;
-			remoteInfo = widget;
+			remoteGlobalIDString = XX219ADAAD1592813AB03DXX;
+			remoteInfo = "My Widget 😄";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -36,7 +38,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				XX09E725E164C2787243F7XX /* widget.appex in Embed Foundation Extensions */,
+				XX6357A9A9DEDF49BD6081XX /* My Widget 😄.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -50,34 +52,36 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = widgetclipdemo/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; name = Info.plist; path = widgetclipdemo/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.objc; name = main.m; path = widgetclipdemo/main.m; sourceTree = "<group>"; };
+		4884E59A2FBB4A9FA3260962 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "widgetclipdemo/noop-file.swift"; sourceTree = "<group>"; };
 		58EEBF8E8E6FB1BC6CAF49B5 /* libPods-widgetclipdemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; fileEncoding = 4; includeInIndex = 0; path = "libPods-widgetclipdemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		5C1CD997CFDA4909B454B1F5 /* noop-file.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "noop-file.swift"; path = "widgetclipdemo/noop-file.swift"; sourceTree = "<group>"; };
-		61C4B10B09FE49798E144845 /* widgetclipdemo-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "widgetclipdemo-Bridging-Header.h"; path = "widgetclipdemo/widgetclipdemo-Bridging-Header.h"; sourceTree = "<group>"; };
 		6C2E3173556A471DD304B334 /* Pods-widgetclipdemo.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-widgetclipdemo.debug.xcconfig"; path = "Target Support Files/Pods-widgetclipdemo/Pods-widgetclipdemo.debug.xcconfig"; sourceTree = "<group>"; };
 		7A4D352CD337FB3A3BF06240 /* Pods-widgetclipdemo.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-widgetclipdemo.release.xcconfig"; path = "Target Support Files/Pods-widgetclipdemo/Pods-widgetclipdemo.release.xcconfig"; sourceTree = "<group>"; };
+		A41C222C9C634C4D9D4623E7 /* widgetclipdemo-Bridging-Header.h */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.c.h; name = "widgetclipdemo-Bridging-Header.h"; path = "widgetclipdemo/widgetclipdemo-Bridging-Header.h"; sourceTree = "<group>"; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = widgetclipdemo/SplashScreen.storyboard; sourceTree = "<group>"; };
 		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
 		XX470101BAEB8E0BBC8B0DXX /* WidgetKit.framework */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = undefined; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		XX4DFF38D47332D6BF0183XX /* SwiftUI.framework */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = undefined; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
-		XXD26DB380DB6D7349BA89XX /* widget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = 4; includeInIndex = 0; path = widget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		XXA12889081EB894481655XX /* AppIntents.framework */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = undefined; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
+		XXBF185C77F1BAFCE93861XX /* My Widget 😄.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = 4; includeInIndex = 0; path = "My Widget 😄.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		XXCAF23C3FC41F82140FA1XX /* ActivityKit.framework */ = {isa = PBXFileReference; fileEncoding = 4; includeInIndex = undefined; lastKnownFileType = wrapper.framework; name = ActivityKit.framework; path = System/Library/Frameworks/ActivityKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		XXA3A32EF7C9F8448A2F6DXX /* Exceptions for "widget" folder in "widget" target */ = {
+		XX5D8C69AEC31EB74E6A81XX /* Exceptions for "widget" folder in "My Widget 😄" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 				"expo-target.config.js",
 			);
-			target = XX6A0644B8C84798435039XX /* widget */;
+			target = XX219ADAAD1592813AB03DXX /* My Widget 😄 */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		XX44182A803FDBF024DEB6XX /* widget */ = {
+		XX5334B7CC062E958C75C1XX /* widget */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				XXA3A32EF7C9F8448A2F6DXX /* Exceptions for "widget" folder in "widget" target */,
+				XX5D8C69AEC31EB74E6A81XX /* Exceptions for "widget" folder in "My Widget 😄" target */,
 			);
 			explicitFileTypes = {
 			};
@@ -103,6 +107,8 @@
 			files = (
 				XX12B55A1EDABF083C3B51XX /* WidgetKit.framework in Frameworks */,
 				XX6A44985675A04437B8C4XX /* SwiftUI.framework in Frameworks */,
+				XX3C562DEF346B45594832XX /* ActivityKit.framework in Frameworks */,
+				XX1A6800511A685AB346D2XX /* AppIntents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,8 +125,8 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
-				5C1CD997CFDA4909B454B1F5 /* noop-file.swift */,
-				61C4B10B09FE49798E144845 /* widgetclipdemo-Bridging-Header.h */,
+				4884E59A2FBB4A9FA3260962 /* noop-file.swift */,
+				A41C222C9C634C4D9D4623E7 /* widgetclipdemo-Bridging-Header.h */,
 			);
 			name = widgetclipdemo;
 			sourceTree = "<group>";
@@ -131,6 +137,8 @@
 				58EEBF8E8E6FB1BC6CAF49B5 /* libPods-widgetclipdemo.a */,
 				XX470101BAEB8E0BBC8B0DXX /* WidgetKit.framework */,
 				XX4DFF38D47332D6BF0183XX /* SwiftUI.framework */,
+				XXCAF23C3FC41F82140FA1XX /* ActivityKit.framework */,
+				XXA12889081EB894481655XX /* AppIntents.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -162,7 +170,7 @@
 			isa = PBXGroup;
 			children = (
 				13B07F961A680F5B00A75B9A /* widgetclipdemo.app */,
-				XXD26DB380DB6D7349BA89XX /* widget.appex */,
+				XXBF185C77F1BAFCE93861XX /* My Widget 😄.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -203,7 +211,7 @@
 		XX3E41C1850246162C0061XX /* expo:targets */ = {
 			isa = PBXGroup;
 			children = (
-				XX44182A803FDBF024DEB6XX /* widget */,
+				XX5334B7CC062E958C75C1XX /* widget */,
 			);
 			name = "expo:targets";
 			path = ../targets;
@@ -225,16 +233,16 @@
 			buildRules = (
 			);
 			dependencies = (
-				XX72D98116FFFA053FA7D5XX /* PBXTargetDependency */,
+				XX8A929EB0D10D043F0ABEXX /* PBXTargetDependency */,
 			);
 			name = widgetclipdemo;
 			productName = widgetclipdemo;
 			productReference = 13B07F961A680F5B00A75B9A /* widgetclipdemo.app */;
 			productType = "com.apple.product-type.application";
 		};
-		XX6A0644B8C84798435039XX /* widget */ = {
+		XX219ADAAD1592813AB03DXX /* My Widget 😄 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = XX2C0040ABF77D36627EBEXX /* Build configuration list for PBXNativeTarget "widget" */;
+			buildConfigurationList = XX0E1B7C3454F9C8294256XX /* Build configuration list for PBXNativeTarget "My Widget 😄" */;
 			buildPhases = (
 				XX074B8811C1CF8E8A3D74XX /* Frameworks */,
 				XXE45443DC38DCFE1DB622XX /* Sources */,
@@ -245,11 +253,11 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				XX44182A803FDBF024DEB6XX /* widget */,
+				XX5334B7CC062E958C75C1XX /* widget */,
 			);
-			name = widget;
-			productName = widget;
-			productReference = XXD26DB380DB6D7349BA89XX /* widget.appex */;
+			name = "My Widget 😄";
+			productName = MyWidget;
+			productReference = XXBF185C77F1BAFCE93861XX /* My Widget 😄.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
@@ -263,9 +271,9 @@
 					13B07F861A680F5B00A75B9A = {
 						LastSwiftMigration = 1250;
 					};
-					XX6A0644B8C84798435039XX = {
+					XX219ADAAD1592813AB03DXX = {
 						CreatedOnToolsVersion = 14.3;
-						DevelopmentTeam = undefined;
+						DevelopmentTeam = QQ57RJ5UTD;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -284,7 +292,7 @@
 			projectRoot = "";
 			targets = (
 				13B07F861A680F5B00A75B9A /* widgetclipdemo */,
-				XX6A0644B8C84798435039XX /* widget */,
+				XX219ADAAD1592813AB03DXX /* My Widget 😄 */,
 			);
 		};
 /* End PBXProject section */
@@ -341,7 +349,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
-				E6C3D77E52EF4AFD83620E01 /* noop-file.swift in Sources */,
+				C0E950667BAB45379268CF3B /* noop-file.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -355,10 +363,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		XX72D98116FFFA053FA7D5XX /* PBXTargetDependency */ = {
+		XX8A929EB0D10D043F0ABEXX /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = XX6A0644B8C84798435039XX /* widget */;
-			targetProxy = XX214904F50ADE23A58C77XX /* PBXContainerItemProxy */;
+			target = XX219ADAAD1592813AB03DXX /* My Widget 😄 */;
+			targetProxy = XXA64E64FBB5E0BCCD0762XX /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -371,6 +379,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = widgetclipdemo/widgetclipdemo.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -403,6 +412,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = widgetclipdemo/widgetclipdemo.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
 				INFOPLIST_FILE = widgetclipdemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -526,7 +536,7 @@
 			};
 			name = Release;
 		};
-		XX007BF18FF5968F511D15XX /* Release */ = {
+		XX2638145AAD3C31E3D763XX /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -541,12 +551,13 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ../targets/widget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = widget;
+				INFOPLIST_KEY_CFBundleDisplayName = "My Widget 😄";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
@@ -556,12 +567,12 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 5;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
-		XX00ECAD6BFE8EC23C2197XX /* Debug */ = {
+		XXF46DABD2EDBAFE170DDCXX /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -575,12 +586,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QQ57RJ5UTD;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ../targets/widget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = widget;
+				INFOPLIST_KEY_CFBundleDisplayName = "My Widget 😄";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
@@ -591,7 +603,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -617,11 +629,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		XX2C0040ABF77D36627EBEXX /* Build configuration list for PBXNativeTarget "widget" */ = {
+		XX0E1B7C3454F9C8294256XX /* Build configuration list for PBXNativeTarget "My Widget 😄" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				XX00ECAD6BFE8EC23C2197XX /* Debug */,
-				XX007BF18FF5968F511D15XX /* Release */,
+				XXF46DABD2EDBAFE170DDCXX /* Debug */,
+				XX2638145AAD3C31E3D763XX /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/apps/widget-demo/targets/widget/expo-target.config.js
+++ b/apps/widget-demo/targets/widget/expo-target.config.js
@@ -1,6 +1,9 @@
 /** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
-module.exports = config => ({
+module.exports = (config) => ({
   type: "widget",
-  icon: 'https://github.com/expo.png',
-  entitlements: { /* Add entitlements */ },
+  name: "My Widget 😄",
+  icon: "https://github.com/expo.png",
+  entitlements: {
+    /* Add entitlements */
+  },
 });

--- a/packages/apple-targets/src/config-plugin.ts
+++ b/packages/apple-targets/src/config-plugin.ts
@@ -51,6 +51,12 @@ export const withTargetsDir: ConfigPlugin<
       );
     }
 
+    if (!evaluatedTargetConfigObject.type) {
+      throw new Error(
+        `Expected target config to have a 'type' property denoting the type of target it is, e.g. 'widget'`
+      );
+    }
+
     config = withWidget(config, {
       appleTeamId,
       ...evaluatedTargetConfigObject,

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -42,6 +42,8 @@ import assert from "assert";
 
 export type XcodeSettings = {
   name: string;
+  /** Name used for internal purposes. This has more strict rules and should be generated. */
+  productName: string;
   /** Directory relative to the project root, (i.e. outside of the `ios` directory) where the widget code should live. */
   cwd: string;
 
@@ -921,7 +923,7 @@ async function applyXcodeChanges(
 
   const targets = getExtensionTargets();
 
-  const productName = props.name;
+  const productName = props.productName;
 
   let targetToUpdate: PBXNativeTarget | undefined =
     targets.find((target) => target.props.productName === productName) ??
@@ -1116,7 +1118,7 @@ async function applyXcodeChanges(
           ? "wrapper.extensionkit-extension"
           : "wrapper.app-extension",
         includeInIndex: 0,
-        path: productName + (isExtension ? ".appex" : ".app"),
+        path: props.name + (isExtension ? ".appex" : ".app"),
         sourceTree: "BUILT_PRODUCTS_DIR",
       }),
       settings: {
@@ -1131,7 +1133,7 @@ async function applyXcodeChanges(
 
     targetToUpdate = project.rootObject.createNativeTarget({
       buildConfigurationList: createConfigurationListForType(project, props),
-      name: productName,
+      name: props.name,
       productName,
       // @ts-expect-error
       productReference:


### PR DESCRIPTION
Replacement for https://github.com/EvanBacon/expo-apple-targets/pull/53 that allows the more expressive `name` property to be used for the display name, and uses a lower-resolution version of the name for all internal properties. This may introduce an annoying change where generated bundle identifiers are different between versions, but this can be fixed by manually defining the `bundleIdentifier` property to whatever you previously published with.