### PR TITLE
feat: Add get and remove methods to extension storage

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -388,6 +388,8 @@ ExtensionStorage.reloadWidget();
 
 - `set(key: string, value: string | number | Record<string, string | number> | Array<Record<string, string | number>> | undefined): void` - Sets a value in the shared storage for a given key. Setting `undefined` will remove the key.
 - `ExtensionStorage.reloadWidget(name?: string): void` - A static method for reloading the widget. Behind the scenes, this calls `WidgetCenter.shared.reloadAllTimelines()`. If given a name, it will reload a specific widget using `WidgetCenter.shared.reloadTimelines(ofKind: timeline)`.
+- `remove(key: string): void` - A method for removing the key from the shared storage.
+- `get(key: string): string | null` - A static method for getting the value from the shared storage.
 
 ### Accessing shared data
 

--- a/packages/apple-targets/ios/ExtensionStorageModule.swift
+++ b/packages/apple-targets/ios/ExtensionStorageModule.swift
@@ -48,6 +48,25 @@ public class ExtensionStorageModule: Module {
         Function("setString") { (key: String, value: String, group: String?) in
             let userDefaults = UserDefaults(suiteName: group)
             userDefaults?.set(value, forKey: key)
+        }        
+
+        Function("get") { (key: String, group: String?) -> String? in
+            let userDefaults = UserDefaults(suiteName: group)
+            if let data = userDefaults?.data(forKey: key) {
+                do {
+                    let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
+                    let jsonData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
+                    return String(data: jsonData, encoding: .utf8)
+                } catch {
+                    print("Error processing JSON data: \(error)")
+                    return nil
+                }
+            }
+            
+            if let value = userDefaults?.object(forKey: key) {
+                return String(describing: value)
+            }
+            return nil
         }
     }
 }

--- a/packages/apple-targets/ios/ExtensionStorageModule.swift
+++ b/packages/apple-targets/ios/ExtensionStorageModule.swift
@@ -57,8 +57,7 @@ public class ExtensionStorageModule: Module {
                     let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
                     let jsonData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
                     return String(data: jsonData, encoding: .utf8)
-                } catch {
-                    print("Error processing JSON data: \(error)")
+                } catch {                    
                     return nil
                 }
             }

--- a/packages/apple-targets/src/ExtensionStorage.ts
+++ b/packages/apple-targets/src/ExtensionStorage.ts
@@ -13,6 +13,7 @@ type NativeModule = {
     value: Record<string, string | number>[],
     suite?: string
   ): boolean;
+  get(key: string, suite?: string): string | null;
 };
 
 // @ts-expect-error
@@ -21,10 +22,11 @@ const ExtensionStorageModule = expo?.modules?.ExtensionStorage;
 const nativeModule: NativeModule = ExtensionStorageModule ?? {
   setInt() {},
   setString() {},
-  reloadWidget() {},
   setObject() {},
+  setArray() {},  
+  reloadWidget() {},
+  get() {},
   remove() {},
-  setArray() {},
 };
 
 const originalSetObject = nativeModule.setObject;
@@ -67,5 +69,13 @@ export class ExtensionStorage {
     } else {
       nativeModule.setObject(key, value, this.appGroup);
     }
+  }
+
+  get(key: string): string | null {      
+    return nativeModule.get(key, this.appGroup);
+  }
+
+  remove(key: string) {
+    nativeModule.remove(key, this.appGroup);
   }
 }


### PR DESCRIPTION
This PR adresses #70 by adding two methods to the shared storage module. 

- `remove(key: string): void` - A method for removing the key from the shared storage.
- `get(key: string): string | null` - A method for getting the value from the shared storage.