### PR TITLE
feat: add support for Safari content blocker extension

### DIFF
--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -20,6 +20,7 @@ export type ExtensionType =
   | "account-auth"
   | "action"
   | "safari"
+  | "content-blocker"
   | "app-intent"
   | "device-activity-monitor";
 
@@ -70,6 +71,7 @@ export const SHOULD_USE_APP_GROUPS_BY_DEFAULT: Record<ExtensionType, boolean> =
     intent: false,
     matter: false,
     safari: false,
+    "content-blocker": false,
     spotlight: false,
     watch: false,
   };
@@ -262,6 +264,14 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
         NSExtensionPrincipalClass:
           "$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler",
         // NSExtensionMainStoryboard: 'MainInterface',
+        NSExtensionPointIdentifier,
+      },
+    });
+  } else if (type === "content-blocker") {
+    return plist.build({
+      NSExtension: {
+        NSExtensionPrincipalClass:
+          "$(PRODUCT_MODULE_NAME).ContentBlockerRequestHandler",
         NSExtensionPointIdentifier,
       },
     });

--- a/packages/apple-targets/src/template/XCBuildConfiguration.json
+++ b/packages/apple-targets/src/template/XCBuildConfiguration.json
@@ -437,6 +437,36 @@
       }
     }
   },
+  "com.apple.Safari.content-blocker": {
+    "default": {
+      "CODE_SIGN_STYLE": "Automatic",
+      "CURRENT_PROJECT_VERSION": 1,
+      "DEVELOPMENT_TEAM": "QQ57RJ5UTD",
+      "GENERATE_INFOPLIST_FILE": "YES",
+      "INFOPLIST_FILE": "../targets/content-blocker/Info.plist",
+      "INFOPLIST_KEY_CFBundleDisplayName": "ContentBlocker",
+      "IPHONEOS_DEPLOYMENT_TARGET": 16.0,
+      "PRODUCT_BUNDLE_IDENTIFIER": "com.bacon.2095.contentBlocker",
+      "PRODUCT_NAME": "$(TARGET_NAME)",
+      "SKIP_INSTALL": "YES",
+      "SWIFT_VERSION": "5.0",
+      "TARGETED_DEVICE_FAMILY": "1,2"
+    },
+    "release": {
+      "COPY_PHASE_STRIP": "NO",
+      "DEBUG_INFORMATION_FORMAT": "dwarf-with-dsym"
+    },
+    "debug": {
+      "DEBUG_INFORMATION_FORMAT": "dwarf",
+      "SWIFT_OPTIMIZATION_LEVEL": "-Onone"
+    },
+    "info": {
+      "NSExtension": {
+        "NSExtensionPointIdentifier": "com.apple.Safari.content-blocker",
+        "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).ContentBlockerRequestHandler"
+      }
+    }
+  },
   "com.apple.share-services": {
     "default": {
       "CLANG_ANALYZER_NONNULL": "YES",

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -611,6 +611,65 @@ function createSafariConfigurationList(
 
   return configurationList;
 }
+function createContentBlockerConfigurationList(
+  project: XcodeProject,
+  {
+    name,
+    cwd,
+    bundleId,
+    deploymentTarget,
+    currentProjectVersion,
+  }: XcodeSettings
+) {
+  const common: BuildSettings = {
+    CODE_SIGN_STYLE: "Automatic",
+    CURRENT_PROJECT_VERSION: currentProjectVersion,
+    INFOPLIST_FILE: cwd + "/Info.plist",
+    INFOPLIST_KEY_CFBundleDisplayName: name,
+    IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
+    PRODUCT_BUNDLE_IDENTIFIER: bundleId,
+    PRODUCT_NAME: "$(TARGET_NAME)",
+    SKIP_INSTALL: "YES",
+    SWIFT_VERSION: "5.0",
+    TARGETED_DEVICE_FAMILY: "1,2",
+    GENERATE_INFOPLIST_FILE: "YES",
+
+    SWIFT_OPTIMIZATION_LEVEL: "-Onone",
+    SWIFT_EMIT_LOC_STRINGS: "YES",
+    CLANG_ENABLE_OBJC_WEAK: "YES",
+    GCC_C_LANGUAGE_STANDARD: "gnu11",
+    CLANG_CXX_LANGUAGE_STANDARD: "gnu++20",
+  };
+
+  const debugBuildConfig = XCBuildConfiguration.create(project, {
+    name: "Debug",
+    buildSettings: {
+      ...common,
+      DEBUG_INFORMATION_FORMAT: "dwarf",
+      SWIFT_ACTIVE_COMPILATION_CONDITIONS: "DEBUG",
+      MTL_ENABLE_DEBUG_INFO: "INCLUDE_SOURCE",
+    },
+  });
+
+  const releaseBuildConfig = XCBuildConfiguration.create(project, {
+    name: "Release",
+    buildSettings: {
+      ...common,
+      SWIFT_COMPILATION_MODE: "wholemodule",
+      SWIFT_OPTIMIZATION_LEVEL: "-O",
+      COPY_PHASE_STRIP: "NO",
+      DEBUG_INFORMATION_FORMAT: "dwarf-with-dsym",
+    },
+  });
+
+  const configurationList = XCConfigurationList.create(project, {
+    buildConfigurations: [debugBuildConfig, releaseBuildConfig],
+    defaultConfigurationIsVisible: 0,
+    defaultConfigurationName: "Release",
+  });
+
+  return configurationList;
+}
 function createAppClipConfigurationList(
   project: XcodeProject,
   {
@@ -879,6 +938,8 @@ function createConfigurationListForType(
     return createShareConfigurationList(project, props);
   } else if (props.type === "safari") {
     return createSafariConfigurationList(project, props);
+  } else if (props.type === "content-blocker") {
+    return createContentBlockerConfigurationList(project, props);
   } else if (props.type === "imessage") {
     return createIMessageConfigurationList(project, props);
   } else if (props.type === "clip") {

--- a/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
+++ b/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
@@ -43,6 +43,14 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for content-blocker 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"content-blocker\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for credentials-provider 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({

--- a/packages/create-target/src/__tests__/createAsync.test.ts
+++ b/packages/create-target/src/__tests__/createAsync.test.ts
@@ -7,6 +7,7 @@ const ALL_TARGET_TYPES = [
   "watch",
   "clip",
   "safari",
+  "content-blocker",
   "share",
   "notification-content",
   "notification-service",

--- a/packages/create-target/src/promptTarget.ts
+++ b/packages/create-target/src/promptTarget.ts
@@ -54,6 +54,7 @@ export const TARGETS = [
   },
   { title: "Spotlight", value: "spotlight", description: "" },
   { title: "Safari Extension", value: "safari", description: "" },
+  { title: "Content Blocker", value: "content-blocker", description: "" },
   { title: "Siri Intent", value: "intent", description: "" },
   { title: "Siri Intent UI", value: "intent-ui", description: "" },
   { title: "Share Extension", value: "share", description: "" },

--- a/packages/create-target/templates/content-blocker/ContentBlockerRequestHandler.swift
+++ b/packages/create-target/templates/content-blocker/ContentBlockerRequestHandler.swift
@@ -1,0 +1,15 @@
+import UIKit
+import MobileCoreServices
+
+class ContentBlockerRequestHandler: NSObject, NSExtensionRequestHandling {
+
+    func beginRequest(with context: NSExtensionContext) {
+        let attachment = NSItemProvider(contentsOf: Bundle.main.url(forResource: "blockerList", withExtension: "json"))!
+        
+        let item = NSExtensionItem()
+        item.attachments = [attachment]
+        
+        context.completeRequest(returningItems: [item], completionHandler: nil)
+    }
+    
+}

--- a/packages/create-target/templates/content-blocker/Info.plist
+++ b/packages/create-target/templates/content-blocker/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.Safari.content-blocker</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ContentBlockerRequestHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/packages/create-target/templates/content-blocker/blockerList.json
+++ b/packages/create-target/templates/content-blocker/blockerList.json
@@ -1,0 +1,10 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": "webkit.svg"
+        }
+    }
+]


### PR DESCRIPTION
# Motivation

There was no support for Safari Content Blocker extensions in the existing target set.

# Execution

https://developer.apple.com/documentation/safariservices/creating-a-content-blocker

- Adds a new 'content-blocker' type to `create-target`
- Includes a default template taken from the existing `fx-content-blocker`
- Added new entry under `XCBuildConfiguration.json` for `com.apple.Safari.content-blocker`.
- Added `createContentBlockerConfigurationList` to `withXcodeChanges.ts`.
- Auto-generates `Info.plist` with proper `NSExtensionPointIdentifier` and `NSExtensionPrincipalClass`.

All changes were modeled after how the regular Safari extension target is implemented.

# Test Plan

I've done very minimal testing so far, but the extension builds & functions as expected.

![IMG_5824](https://github.com/user-attachments/assets/146ad96c-9bfa-440f-b406-286285dd3d2c)

