### PR TITLE
move @react-native/normalize-colors to peer deps

### DIFF
--- a/packages/apple-targets/package.json
+++ b/packages/apple-targets/package.json
@@ -34,9 +34,11 @@
   "license": "MIT",
   "dependencies": {
     "@bacons/xcode": "1.0.0-alpha.24",
-    "@react-native/normalize-colors": "^0.76.1",
     "glob": "^10.4.2",
     "debug": "^4.3.4"
+  },
+  "peerDependencies": {
+    "@react-native/normalize-colors": "*",
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",


### PR DESCRIPTION
# Motivation

Just tried installing to a RN 0.79 project and `@react-native/normalize-colors` with version 0.76 was added to the project dependencies, which probably isn't intentional.

# Execution

move `@react-native/normalize-colors` to peer deps so it's not automatically installed

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
