### PR TITLE
Updated the invalid prebuild tarball URL to a valid format in Readme

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -42,7 +42,7 @@ Some targets have special entitlements behavior:
 Any changes you make outside of the `expo:targets` directory in Xcode are subject to being overwritten by the next `npx expo prebuild --clean`. Check to see if the settings you want to toggle are available in the Info.plist or the `expo-target.config.js` file.
 If you modify the `expo-target.config.js` or your root `app.json`, you will need to re-run `npx expo prebuild --clean` to sync the changes.
 
-You can use the custom Prebuild template `--template node_modules/@bacons/apple-targets/prebuild-blank.tgz` to create a build without React Native, this can make development a bit faster since there's less to compile. This is an advanced technique for development **NOT PRODUCTION** and is not intended to be used with third-party Config Plugins.
+You can use the custom Prebuild template `--template ./node_modules/@bacons/apple-targets/prebuild-blank.tgz` to create a build without React Native, this can make development a bit faster since there's less to compile. This is an advanced technique for development **NOT PRODUCTION** and is not intended to be used with third-party Config Plugins.
 
 ## Target config
 
@@ -320,7 +320,7 @@ If you experience issues building widgets, it might be because React Native is s
 Some workarounds:
 
 - Clear the SwiftUI previews cache: `xcrun simctl --set previews delete all`
-- Prebuild without React Native: `npx expo prebuild --template node_modules/@bacons/apple-targets/prebuild-blank.tgz --clean`
+- Prebuild without React Native: `npx expo prebuild --template ./node_modules/@bacons/apple-targets/prebuild-blank.tgz --clean`
 - If the widget doesn't show on the home screen when building the app, use iOS 18. You can long press the app icon and select the widget display options to transform the app icon into the widget.
 
 ## Sharing data between targets


### PR DESCRIPTION
Issue:
`npx expo prebuild --template ./node_modules/@bacons/apple-targets/prebuild-blank.tgz --clean` 

The command was failing with the following error:
`Found invalid GitHub URL. Please fix the URL and try again`

Fix:
Updated the command to a valid format
`npx expo prebuild --template ./node_modules/@bacons/apple-targets/prebuild-blank.tgz --clean`

Before:
![invalid](https://github.com/user-attachments/assets/16fe3822-ff50-425f-9f96-d1dba6a20919)

After:
![valid](https://github.com/user-attachments/assets/8b8dc1bf-b842-4573-935a-4ba466787a38)
