### PR TITLE
Support Watch Widget Extensions

### DIFF
--- a/packages/apple-targets/src/config-plugin.ts
+++ b/packages/apple-targets/src/config-plugin.ts
@@ -33,7 +33,7 @@ export const withTargetsDir: ConfigPlugin<
     absolute: true,
   });
 
-  targets.forEach((configPath) => {
+  const evaluatedTargets = targets.map((configPath) => {
     const targetConfig = require(configPath);
     let evaluatedTargetConfigObject = targetConfig;
     // If it's a function, evaluate it
@@ -57,11 +57,28 @@ export const withTargetsDir: ConfigPlugin<
       );
     }
 
-    config = withWidget(config, {
-      appleTeamId,
+    return {
       ...evaluatedTargetConfigObject,
       directory: path.relative(projectRoot, path.dirname(configPath)),
       configPath,
+    };
+  });
+
+  // Sort so that any watch-widget targets come after any watch targets
+  evaluatedTargets.sort((a, b) => {
+    if (a.type === "watch-widget") {
+      return 1;
+    }
+    if (b.type === "watch-widget") {
+      return -1;
+    }
+    return 0;
+  });
+
+  evaluatedTargets.forEach((target) => {
+    config = withWidget(config, {
+      appleTeamId,
+      ...target,
     });
   });
 

--- a/packages/apple-targets/src/config-plugin.ts
+++ b/packages/apple-targets/src/config-plugin.ts
@@ -64,13 +64,13 @@ export const withTargetsDir: ConfigPlugin<
     };
   });
 
-  // Sort so that any watch-widget targets come after any watch targets
+  // Sort so that any watch-widget targets come before any watch targets, LIFO
   evaluatedTargets.sort((a, b) => {
     if (a.type === "watch-widget") {
-      return 1;
+      return -1;
     }
     if (b.type === "watch-widget") {
-      return -1;
+      return 1;
     }
     return 0;
   });

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -15,6 +15,7 @@ export type ExtensionType =
   | "imessage"
   | "clip"
   | "watch"
+  | "watch-widget"
   | "location-push"
   | "credentials-provider"
   | "account-auth"
@@ -305,6 +306,7 @@ export function productTypeForType(type: ExtensionType) {
 export function needsEmbeddedSwift(type: ExtensionType) {
   return [
     "watch",
+    "watch-widget",
     "spotlight",
     "share",
     "intent",
@@ -317,7 +319,7 @@ export function needsEmbeddedSwift(type: ExtensionType) {
 }
 
 export function getFrameworksForType(type: ExtensionType) {
-  if (type === "widget") {
+  if (type === "widget" || type === "watch-widget") {
     return [
       // CD07060B2A2EBE2E009C1192 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
       "WidgetKit",

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -320,7 +320,7 @@ export function needsEmbeddedSwift(type: ExtensionType) {
 }
 
 export function getFrameworksForType(type: ExtensionType) {
-  if (type === "widget" || type === "watch-widget") {
+  if (type === "widget") {
     return [
       // CD07060B2A2EBE2E009C1192 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
       "WidgetKit",
@@ -329,6 +329,8 @@ export function getFrameworksForType(type: ExtensionType) {
       "ActivityKit",
       "AppIntents",
     ];
+  } else if (type === "watch-widget") {
+    return ["AppIntents", "WidgetKit", "SwiftUI"];
   } else if (type === "intent") {
     return ["Intents"];
   } else if (type === "intent-ui") {

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -364,6 +364,15 @@ export function isNativeTargetOfType(
     );
   }
   if (
+    type === "watch-widget" &&
+    target.props.productType === "com.apple.product-type.app-extension"
+  ) {
+    return (
+      "WATCHOS_DEPLOYMENT_TARGET" in
+      target.getDefaultConfiguration().props.buildSettings
+    );
+  }
+  if (
     type === "clip" &&
     target.props.productType ===
       "com.apple.product-type.application.on-demand-install-capable"

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -364,13 +364,13 @@ export function isNativeTargetOfType(
     );
   }
   if (
-    type === "watch-widget" &&
+    (type === "watch-widget" || type === "widget") &&
     target.props.productType === "com.apple.product-type.app-extension"
   ) {
     return (
       "WATCHOS_DEPLOYMENT_TARGET" in
       target.getDefaultConfiguration().props.buildSettings
-    );
+    ) && type === "watch-widget"
   }
   if (
     type === "clip" &&

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -57,6 +57,7 @@ export const SHOULD_USE_APP_GROUPS_BY_DEFAULT: Record<ExtensionType, boolean> =
     "bg-download": true,
     clip: true,
     widget: true,
+    "watch-widget": true,
     "account-auth": false,
     "credentials-provider": false,
     "device-activity-monitor": false,

--- a/packages/apple-targets/src/withWidget.ts
+++ b/packages/apple-targets/src/withWidget.ts
@@ -334,11 +334,19 @@ const withWidget: ConfigPlugin<Props> = (config, props) => {
     }
 
     let bundleId = mainAppBundleId;
+
+    // Watch widgets are embedded in the watch app, so the root bundle identifier needs to
+    // match the watch app's bundle identifier. If the bundle identifier is not set, then well 
+    // default to using the default main app's bundle identifier + watch suffix
+    if (props.type === "watch-widget") {
+      bundleId += ".watch";
+    }
+
     bundleId += ".";
 
     // Generate the bundle identifier. This logic needs to remain generally stable since it's used for a permanent value.
     // Key here is simplicity and predictability since it's already appended to the main app's bundle identifier.
-    return mainAppBundleId + "." + getSanitizedBundleIdentifier(props.type);
+    return bundleId + getSanitizedBundleIdentifier(props.type);
   })();
 
   const deviceFamilies: DeviceFamily[] = config.ios?.isTabletOnly

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -553,10 +553,10 @@ function createWatchWidgetConfigurationList(
   // NOTE: No base Info.plist needed.
 
   const common: BuildSettings = {
+    
     CLANG_ANALYZER_NONNULL: "YES",
     CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
     CLANG_CXX_LANGUAGE_STANDARD: "gnu++20",
-
     CLANG_ENABLE_OBJC_WEAK: "YES",
     CLANG_WARN_DOCUMENTATION_COMMENTS: "YES",
     CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER: "YES",

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -1,5 +1,6 @@
 import {
   PBXBuildFile,
+  PBXCopyFilesBuildPhase,
   PBXFileReference,
   PBXFileSystemSynchronizedBuildFileExceptionSet,
   PBXFileSystemSynchronizedRootGroup,
@@ -1238,10 +1239,20 @@ async function applyXcodeChanges(
       }) as PBXNativeTarget | undefined;
 
       if (watchAppTarget) {
-        const watchCopyPhase = watchAppTarget.getCopyBuildPhaseForTarget(targetToUpdate);
-        if (!watchCopyPhase.getBuildFile(appExtensionBuildFile.props.fileRef)) {
-          watchCopyPhase.props.files.push(appExtensionBuildFile);
-        }
+        watchAppTarget.createBuildPhase(
+          PBXCopyFilesBuildPhase,
+          {
+            dstPath: "",
+            dstSubfolderSpec: 6,
+            name: "Embed App Extensions",
+            files: [
+              PBXBuildFile.create(project, {
+                fileRef: appExtensionBuildFile.props.fileRef,
+              }),
+            ],
+            runOnlyForDeploymentPostprocessing: 0,
+          }
+        );
       }
     }
   }

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -553,7 +553,6 @@ function createWatchWidgetConfigurationList(
   // NOTE: No base Info.plist needed.
 
   const common: BuildSettings = {
-    ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon",
     CLANG_ANALYZER_NONNULL: "YES",
     CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
     CLANG_CXX_LANGUAGE_STANDARD: "gnu++20",


### PR DESCRIPTION
# Motivation

This adds support for watch widget extensions #6 

# Execution

This builds off #17 #14 #16  and makes it as automatic as possible. This may be a bit sloppy, but hopefully there is a path to make this available for everyone.

# Test Plan

I created a watch target and a watch widget target and ran it with xcode and the simulator:

![simulator_screenshot_23E66F8B-2634-4829-87F1-3A908D0E04A8](https://github.com/user-attachments/assets/539672bf-3f4d-473b-aa89-13e75c8f7249)

![simulator_screenshot_CDBE282E-2276-4315-8AF7-8EE3AF4BAB4D](https://github.com/user-attachments/assets/23287485-4872-452e-8939-b1338ba59c87)
