### PR TITLE
Added optional displayName field

### DIFF
--- a/packages/apple-targets/src/config.ts
+++ b/packages/apple-targets/src/config.ts
@@ -140,6 +140,9 @@ export type Config = {
 
   /** Should the release build export the JS bundle and embed. Intended for App Clips and Share Extensions where you may want to use React Native. */
   exportJs?: boolean;
+
+  //** Optional display name for target. Defaults to name if none provided. */
+  displayName?: string;
 };
 
 export type ConfigFunction = (

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -71,6 +71,8 @@ export type XcodeSettings = {
   orientation?: "default" | "portrait" | "landscape";
 
   deviceFamilies?: DeviceFamily[];
+
+  displayName?: string;
 };
 
 export type DeviceFamily = "phone" | "tablet";
@@ -93,6 +95,7 @@ function createNotificationContentConfigurationList(
     bundleId,
     deploymentTarget,
     currentProjectVersion,
+    displayName,
   }: XcodeSettings
 ) {
   const common: BuildSettings = {
@@ -110,7 +113,7 @@ function createNotificationContentConfigurationList(
     GENERATE_INFOPLIST_FILE: "YES",
     CURRENT_PROJECT_VERSION: currentProjectVersion,
     INFOPLIST_FILE: cwd + "/Info.plist",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     INFOPLIST_KEY_NSHumanReadableCopyright: "",
     IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
     LD_RUNPATH_SEARCH_PATHS: [
@@ -164,6 +167,7 @@ function createExtensionConfigurationListFromTemplate(
   extensionType: string,
   {
     name,
+    displayName,
     cwd,
     bundleId,
     deploymentTarget,
@@ -186,7 +190,7 @@ function createExtensionConfigurationListFromTemplate(
   const dynamic: Partial<BuildSettings> = {
     CURRENT_PROJECT_VERSION: currentProjectVersion,
     INFOPLIST_FILE: cwd + "/Info.plist",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
     PRODUCT_BUNDLE_IDENTIFIER: bundleId,
   };
@@ -225,7 +229,7 @@ function createExtensionConfigurationListFromTemplate(
 
 function createAppIntentConfigurationList(
   project: XcodeProject,
-  { name, cwd, bundleId }: XcodeSettings
+  { name, cwd, bundleId, displayName }: XcodeSettings
 ) {
   const commonBuildSettings: BuildSettings = {
     // @ts-expect-error
@@ -244,7 +248,7 @@ function createAppIntentConfigurationList(
     GCC_C_LANGUAGE_STANDARD: "gnu17",
     GENERATE_INFOPLIST_FILE: "YES",
     INFOPLIST_FILE: cwd + "/Info.plist",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     INFOPLIST_KEY_NSHumanReadableCopyright: "",
     IPHONEOS_DEPLOYMENT_TARGET: "17.0",
     LD_RUNPATH_SEARCH_PATHS: [
@@ -297,6 +301,7 @@ function createShareConfigurationList(
   project: XcodeProject,
   {
     name,
+    displayName,
     cwd,
     bundleId,
     deploymentTarget,
@@ -317,7 +322,7 @@ function createShareConfigurationList(
     GENERATE_INFOPLIST_FILE: "YES",
     CURRENT_PROJECT_VERSION: currentProjectVersion,
     INFOPLIST_FILE: cwd + "/Info.plist",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     INFOPLIST_KEY_NSHumanReadableCopyright: "",
     IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
     LD_RUNPATH_SEARCH_PATHS: [
@@ -388,6 +393,7 @@ function createIMessageConfigurationList(
     bundleId,
     deploymentTarget,
     currentProjectVersion,
+    displayName,
   }: XcodeSettings
 ) {
   const common: BuildSettings = {
@@ -405,7 +411,7 @@ function createIMessageConfigurationList(
     GENERATE_INFOPLIST_FILE: "YES",
     CURRENT_PROJECT_VERSION: currentProjectVersion,
     INFOPLIST_FILE: cwd + "/Info.plist",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     INFOPLIST_KEY_NSHumanReadableCopyright: "",
     IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
     LD_RUNPATH_SEARCH_PATHS: [
@@ -459,6 +465,7 @@ function createWatchAppConfigurationList(
     deploymentTarget,
     currentProjectVersion,
     hasAccentColor,
+    displayName,
   }: XcodeSettings
 ) {
   const mainAppTarget = getMainAppTarget(project).getDefaultConfiguration();
@@ -480,7 +487,7 @@ function createWatchAppConfigurationList(
     GCC_C_LANGUAGE_STANDARD: "gnu11",
     INFOPLIST_FILE: cwd + "/Info.plist",
     GENERATE_INFOPLIST_FILE: "YES",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     INFOPLIST_KEY_UISupportedInterfaceOrientations:
       "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown",
     INFOPLIST_KEY_WKCompanionAppBundleIdentifier:
@@ -541,6 +548,7 @@ function createSafariConfigurationList(
   project: XcodeProject,
   {
     name,
+    displayName,
     cwd,
     bundleId,
     deploymentTarget,
@@ -560,7 +568,7 @@ function createSafariConfigurationList(
     GENERATE_INFOPLIST_FILE: "YES",
     CURRENT_PROJECT_VERSION: currentProjectVersion,
     INFOPLIST_FILE: cwd + "/Info.plist",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     INFOPLIST_KEY_NSHumanReadableCopyright: "",
     IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
     LD_RUNPATH_SEARCH_PATHS: [
@@ -615,6 +623,7 @@ function createAppClipConfigurationList(
   project: XcodeProject,
   {
     name,
+    displayName,
     cwd,
     bundleId,
     deploymentTarget,
@@ -628,7 +637,7 @@ function createAppClipConfigurationList(
   const dynamic: Partial<BuildSettings> = {
     CURRENT_PROJECT_VERSION: currentProjectVersion,
     INFOPLIST_FILE: cwd + "/Info.plist",
-    INFOPLIST_KEY_CFBundleDisplayName: name,
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
     IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
     MARKETING_VERSION: "1.0",
     PRODUCT_BUNDLE_IDENTIFIER: bundleId,
@@ -772,6 +781,7 @@ function createWidgetConfigurationList(
     bundleId,
     deploymentTarget,
     currentProjectVersion,
+    displayName,
   }: XcodeSettings
 ) {
   const debugBuildConfig = XCBuildConfiguration.create(project, {
@@ -792,7 +802,7 @@ function createWidgetConfigurationList(
       GCC_C_LANGUAGE_STANDARD: "gnu11",
       GENERATE_INFOPLIST_FILE: "YES",
       INFOPLIST_FILE: cwd + "/Info.plist",
-      INFOPLIST_KEY_CFBundleDisplayName: name,
+      INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
       INFOPLIST_KEY_NSHumanReadableCopyright: "",
       IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
       LD_RUNPATH_SEARCH_PATHS: [
@@ -833,7 +843,7 @@ function createWidgetConfigurationList(
       GCC_C_LANGUAGE_STANDARD: "gnu11",
       GENERATE_INFOPLIST_FILE: "YES",
       INFOPLIST_FILE: cwd + "/Info.plist",
-      INFOPLIST_KEY_CFBundleDisplayName: name,
+      INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
       INFOPLIST_KEY_NSHumanReadableCopyright: "",
       IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
       LD_RUNPATH_SEARCH_PATHS: [


### PR DESCRIPTION
# Motivation

Prior to this you could only have a name for a target, but not a display name. This doesn't matter for most targets, but is an issue for apple watch targets. Apple review expects the apple watch app to be named the same as the iPhone app in most cases (i.e adding a `watchOS` suffix can lead to a rejection). 

This PR makes it so you can specify a separate `displayName` field. If none provided, it defaults to `name`. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# Execution

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

