### PR TITLE
feat: add support for infoPlist in expo-target.config

### DIFF
--- a/packages/apple-targets/src/config.ts
+++ b/packages/apple-targets/src/config.ts
@@ -1,4 +1,5 @@
 import { ExtensionType } from "./target";
+import { PlistValue } from "@expo/plist";
 
 // Shape based on tailwind
 // https://tailwindcss.com/docs/customizing-colors
@@ -140,6 +141,9 @@ export type Config = {
 
   /** Should the release build export the JS bundle and embed. Intended for App Clips and Share Extensions where you may want to use React Native. */
   exportJs?: boolean;
+
+  /** Optional Info.plist entries */
+  infoPlist: Record<string, PlistValue>;
 };
 
 export type ConfigFunction = (


### PR DESCRIPTION
# Motivation

I need more configuration options in the expo-target.config.js. In my case, I wanted to set a backend URL directly from the .env file and read it in the widget to make an API call.

# Execution

To add this feature I followed current approach of extending the widget files structure based on the config file. It works similarly to the app.config.json infoPlist property. Through the config file, we are able to modify the widget's Info.plist.

# Test Plan

To test this feature extend your expo-target.config.js with infoPlist object. Then do prebuild and see if Info.plist in the targets/widget folder is correctly updated

Example:
```js
// expo-target.config.js

module.exports = () => {
  const testValue = "Something that I need in info plist"
  
  return {
  type: 'widget',
  // ...rest
  infoPlist:{
    testValueName: testValue
  }
 }
}

```

**npx expo prebuild -p ios --clean**

<img width="600" height="238" alt="Screenshot 2025-09-18 at 08 09 03" src="https://github.com/user-attachments/assets/f367a789-e772-499c-bc76-f4587275c84c" />
