### PR TITLE
Network extensions

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -299,7 +299,11 @@ Ideally, this would be generated automatically based on a fully qualified Xcode 
 | location-push           | Location Push Service Extension    |
 | credentials-provider    | Credentials Provider Extension     |
 | account-auth            | Account Authentication Extension   |
-| device-activity-monitor | Device Activity Monitor Extension  |
+| network-packet-tunnel   | Packet Tunnel Network Extension    |
+| network-app-proxy       | App Proxy Network Extension        |
+| network-dns-proxy       | DNS Proxy Network Extension        |
+| network-filter-data     | Filter Data Network Extension      |
+
 
 <!-- | imessage             | iMessage Extension               | -->
 

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -21,7 +21,11 @@ export type ExtensionType =
   | "action"
   | "safari"
   | "app-intent"
-  | "device-activity-monitor";
+  | "device-activity-monitor"
+  | "network-packet-tunnel"
+  | "network-app-proxy"
+  | "network-content-filter"
+  | "network-dns-proxy";
 
 export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =
   {

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -24,7 +24,7 @@ export type ExtensionType =
   | "device-activity-monitor"
   | "network-packet-tunnel"
   | "network-app-proxy"
-  | "network-content-filter"
+  | "network-filter-data"
   | "network-dns-proxy";
 
 export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =
@@ -49,7 +49,11 @@ export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =
     "com.apple.services": "action",
     "com.apple.appintents-extension": "app-intent",
     "com.apple.deviceactivity.monitor-extension": "device-activity-monitor",
-    // "com.apple.intents-service": "intents",
+  // "com.apple.intents-service": "intents",
+    "com.apple.networkextension.packet-tunnel": "network-packet-tunnel",
+    "com.apple.networkextension.app-proxy": "network-app-proxy",
+    "com.apple.networkextension.dns-proxy": "network-dns-proxy",
+    "com.apple.networkextension.filter-data": "network-filter-data",
   };
 
 // An exhaustive list of extension types that should sync app groups from the main target by default when
@@ -76,221 +80,254 @@ export const SHOULD_USE_APP_GROUPS_BY_DEFAULT: Record<ExtensionType, boolean> =
     safari: false,
     spotlight: false,
     watch: false,
+    "network-packet-tunnel": false,
+    "network-app-proxy": false,
+    "network-dns-proxy": false,
+    "network-filter-data": false,
   };
 
 // TODO: Maybe we can replace `NSExtensionPrincipalClass` with the `@main` annotation that newer extensions use?
 export function getTargetInfoPlistForType(type: ExtensionType) {
   // TODO: Use exhaustive switch to ensure external contributors don't forget to add this.
-  if (type === "watch") {
-    return plist.build({});
-  } else if (type === "action") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionAttributes: {
-          NSExtensionActivationRule: {
-            NSExtensionActivationSupportsFileWithMaxCount: 0,
-            NSExtensionActivationSupportsImageWithMaxCount: 0,
-            NSExtensionActivationSupportsMovieWithMaxCount: 0,
-            NSExtensionActivationSupportsText: false,
-            NSExtensionActivationSupportsWebURLWithMaxCount: 1,
-          },
-          NSExtensionJavaScriptPreprocessingFile: "assets/index",
-          NSExtensionServiceAllowsFinderPreviewItem: true,
-          NSExtensionServiceAllowsTouchBarItem: true,
-          NSExtensionServiceFinderPreviewIconName: "NSActionTemplate",
-          NSExtensionServiceTouchBarBezelColorName: "TouchBarBezel",
-          NSExtensionServiceTouchBarIconName: "NSActionTemplate",
-        },
-        NSExtensionPointIdentifier: "com.apple.services",
-        NSExtensionPrincipalClass:
-          "$(PRODUCT_MODULE_NAME).ActionRequestHandler",
-      },
-    });
-  } else if (type === "app-intent") {
-    return plist.build({
-      EXAppExtensionAttributes: {
-        EXExtensionPointIdentifier: "com.apple.appintents-extension",
-      },
-    });
-  } else if (type === "clip") {
-    return plist.build({
-      CFBundleName: "$(PRODUCT_NAME)",
-      CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)",
-      CFBundleVersion: "$(CURRENT_PROJECT_VERSION)",
-      CFBundleExecutable: "$(EXECUTABLE_NAME)",
-      CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)",
-      CFBundleShortVersionString: "$(MARKETING_VERSION)",
-      UIApplicationSupportsIndirectInputEvents: true,
-      NSAppClip: {
-        NSAppClipRequestEphemeralUserNotification: false,
-        NSAppClipRequestLocationConfirmation: false,
-      },
-      NSAppTransportSecurity: {
-        NSAllowsArbitraryLoads: false,
-        NSAllowsLocalNetworking: true,
-      },
-      UILaunchStoryboardName: "SplashScreen",
-      UIUserInterfaceStyle: "Automatic",
-      UIViewControllerBasedStatusBarAppearance: false,
-    });
-  }
-  const NSExtensionPointIdentifier = Object.keys(
+
+    const NSExtensionPointIdentifier = Object.keys(
     KNOWN_EXTENSION_POINT_IDENTIFIERS
   ).find((key) => KNOWN_EXTENSION_POINT_IDENTIFIERS[key] === type);
 
-  if (type === "imessage") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionPointIdentifier,
-        // This is hardcoded as there is no Swift code in the imessage extension.
-        NSExtensionPrincipalClass: "StickerBrowserViewController",
-      },
-    });
-  } else if (type === "account-auth") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionPointIdentifier,
+  switch (type) {
+    case "watch":
+      return plist.build({});
+    case "action":
+      return plist.build({
+        NSExtension: {
+          NSExtensionAttributes: {
+            NSExtensionActivationRule: {
+              NSExtensionActivationSupportsFileWithMaxCount: 0,
+              NSExtensionActivationSupportsImageWithMaxCount: 0,
+              NSExtensionActivationSupportsMovieWithMaxCount: 0,
+              NSExtensionActivationSupportsText: false,
+              NSExtensionActivationSupportsWebURLWithMaxCount: 1,
+            },
+            NSExtensionJavaScriptPreprocessingFile: "assets/index",
+            NSExtensionServiceAllowsFinderPreviewItem: true,
+            NSExtensionServiceAllowsTouchBarItem: true,
+            NSExtensionServiceFinderPreviewIconName: "NSActionTemplate",
+            NSExtensionServiceTouchBarBezelColorName: "TouchBarBezel",
+            NSExtensionServiceTouchBarIconName: "NSActionTemplate",
+          },
+          NSExtensionPointIdentifier: "com.apple.services",
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).ActionRequestHandler",
+        },
+      });
+    case "app-intent":
+       return plist.build({
+          EXAppExtensionAttributes: {
+          EXExtensionPointIdentifier: "com.apple.appintents-extension",
+        },
+       });
+    case "clip":
+      return plist.build({
+        CFBundleName: "$(PRODUCT_NAME)",
+        CFBundleIdentifier: "$(PRODUCT_BUNDLE_IDENTIFIER)",
+        CFBundleVersion: "$(CURRENT_PROJECT_VERSION)",
+        CFBundleExecutable: "$(EXECUTABLE_NAME)",
+        CFBundlePackageType: "$(PRODUCT_BUNDLE_PACKAGE_TYPE)",
+        CFBundleShortVersionString: "$(MARKETING_VERSION)",
+        UIApplicationSupportsIndirectInputEvents: true,
+        NSAppClip: {
+          NSAppClipRequestEphemeralUserNotification: false,
+          NSAppClipRequestLocationConfirmation: false,
+        },
+        NSAppTransportSecurity: {
+          NSAllowsArbitraryLoads: false,
+          NSAllowsLocalNetworking: true,
+        },
+        UILaunchStoryboardName: "SplashScreen",
+        UIUserInterfaceStyle: "Automatic",
+        UIViewControllerBasedStatusBarAppearance: false,
+      });
+    case "imessage":
+      return plist.build({
+            NSExtension: {
+              NSExtensionPointIdentifier,
+              // This is hardcoded as there is no Swift code in the imessage extension.
+              NSExtensionPrincipalClass: "StickerBrowserViewController",
+            },
+      });
+    case "account-auth":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPointIdentifier,
 
-        NSExtensionPrincipalClass:
-          "$(PRODUCT_MODULE_NAME).AccountAuthViewController",
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).AccountAuthViewController",
 
-        NSExtensionAttributes: {
-          ASAccountAuthenticationModificationSupportsStrongPasswordChange: true,
-          ASAccountAuthenticationModificationSupportsUpgradeToSignInWithApple:
-            true,
+          NSExtensionAttributes: {
+            ASAccountAuthenticationModificationSupportsStrongPasswordChange: true,
+            ASAccountAuthenticationModificationSupportsUpgradeToSignInWithApple:
+              true,
+          },
         },
-      },
-    });
-  } else if (type === "credentials-provider") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionPointIdentifier,
-        NSExtensionPrincipalClass:
-          "$(PRODUCT_MODULE_NAME).CredentialProviderViewController",
-      },
-    });
-  } else if (type === "notification-service") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionAttributes: {
-          NSExtensionActivationRule: "TRUEPREDICATE",
+      });
+    case "credentials-provider":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).CredentialProviderViewController",
         },
-        // TODO: Update `NotificationService` dynamically
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).NotificationService",
-        // NSExtensionMainStoryboard: 'MainInterface',
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "quicklook-thumbnail") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionAttributes: {
-          QLSupportedContentTypes: [],
-          QLThumbnailMinimumDimension: 0,
+      });
+    case "notification-service":
+      return plist.build({
+        NSExtension: {
+          NSExtensionAttributes: {
+            NSExtensionActivationRule: "TRUEPREDICATE",
+          },
+          // TODO: Update `NotificationService` dynamically
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).NotificationService",
+          // NSExtensionMainStoryboard: 'MainInterface',
+          NSExtensionPointIdentifier,
         },
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ThumbnailProvider",
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "spotlight") {
-    return plist.build({
-      CSExtensionLabel: "myImporter",
-      NSExtension: {
-        NSExtensionAttributes: {
-          CSSupportedContentTypes: ["com.example.plain-text"],
+      });
+    case "quicklook-thumbnail":
+      return plist.build({
+        NSExtension: {
+          NSExtensionAttributes: {
+            QLSupportedContentTypes: [],
+            QLThumbnailMinimumDimension: 0,
+          },
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ThumbnailProvider",
+          NSExtensionPointIdentifier,
         },
-        // TODO: Update `ImportExtension` dynamically
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ImportExtension",
-        // NSExtensionMainStoryboard: 'MainInterface',
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "share") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionAttributes: {
-          NSExtensionActivationRule: "TRUEPREDICATE",
+      });
+    case "spotlight":
+       return plist.build({
+        CSExtensionLabel: "myImporter",
+        NSExtension: {
+          NSExtensionAttributes: {
+            CSSupportedContentTypes: ["com.example.plain-text"],
+          },
+          // TODO: Update `ImportExtension` dynamically
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ImportExtension",
+          // NSExtensionMainStoryboard: 'MainInterface',
+          NSExtensionPointIdentifier,
         },
-        // TODO: Update `ShareViewController` dynamically
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ShareViewController",
-        // NSExtensionMainStoryboard: 'MainInterface',
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "intent-ui") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionAttributes: {
-          IntentsSupported: ["INSendMessageIntent"],
+      });
+    case "share":
+      return plist.build({
+        NSExtension: {
+          NSExtensionAttributes: {
+            NSExtensionActivationRule: "TRUEPREDICATE",
+          },
+          // TODO: Update `ShareViewController` dynamically
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).ShareViewController",
+          // NSExtensionMainStoryboard: 'MainInterface',
+          NSExtensionPointIdentifier,
         },
-        // TODO: Update `IntentViewController` dynamically
-        NSExtensionPrincipalClass:
-          "$(PRODUCT_MODULE_NAME).IntentViewController",
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "intent") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionAttributes: {
-          IntentsRestrictedWhileLocked: [],
-          IntentsSupported: [
-            "INSendMessageIntent",
-            "INSearchForMessagesIntent",
-            "INSetMessageAttributeIntent",
-          ],
+      });
+    case "intent-ui":
+      return plist.build({
+        NSExtension: {
+          NSExtensionAttributes: {
+            IntentsSupported: ["INSendMessageIntent"],
+          },
+          // TODO: Update `IntentViewController` dynamically
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).IntentViewController",
+          NSExtensionPointIdentifier,
         },
-        // TODO: Update `IntentHandler` dynamically
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).IntentHandler",
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "matter") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).RequestHandler",
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "location-push") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).LocationPushService",
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "safari") {
-    return plist.build({
-      NSExtension: {
-        // TODO: Update `SafariWebExtensionHandler` dynamically
-        NSExtensionPrincipalClass:
-          "$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler",
-        // NSExtensionMainStoryboard: 'MainInterface',
-        NSExtensionPointIdentifier,
-      },
-    });
-  } else if (type === "notification-content") {
-    return plist.build({
-      NSExtension: {
-        NSExtensionAttributes: {
-          UNNotificationExtensionCategory: "myNotificationCategory",
-          UNNotificationExtensionInitialContentSizeRatio: 1,
+      });
+    case "intent":
+      return plist.build({
+        NSExtension: {
+          NSExtensionAttributes: {
+            IntentsRestrictedWhileLocked: [],
+            IntentsSupported: [
+              "INSendMessageIntent",
+              "INSearchForMessagesIntent",
+              "INSetMessageAttributeIntent",
+            ],
+          },
+          // TODO: Update `IntentHandler` dynamically
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).IntentHandler",
+          NSExtensionPointIdentifier,
         },
-        // TODO: Update `NotificationViewController` dynamically
-        NSExtensionPrincipalClass:
-          "$(PRODUCT_MODULE_NAME).NotificationViewController",
-        // NSExtensionMainStoryboard: 'MainInterface',
-        NSExtensionPointIdentifier,
-      },
-    });
+      });
+    case "matter":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).RequestHandler",
+          NSExtensionPointIdentifier,
+        },
+      });
+    case "location-push":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).LocationPushService",
+          NSExtensionPointIdentifier,
+        },
+      });
+    case "safari":
+      return plist.build({
+        NSExtension: {
+          // TODO: Update `SafariWebExtensionHandler` dynamically
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler",
+          // NSExtensionMainStoryboard: 'MainInterface',
+          NSExtensionPointIdentifier,
+        },
+      });
+    case "notification-content":
+      return plist.build({
+        NSExtension: {
+          NSExtensionAttributes: {
+            UNNotificationExtensionCategory: "myNotificationCategory",
+            UNNotificationExtensionInitialContentSizeRatio: 1,
+          },
+          // TODO: Update `NotificationViewController` dynamically
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).NotificationViewController",
+          // NSExtensionMainStoryboard: 'MainInterface',
+          NSExtensionPointIdentifier,
+        },
+      });
+    case "network-packet-tunnel":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPointIdentifier: "com.apple.networkextension.packet-tunnel",
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).PacketTunnelProvider",
+        },
+      });
+    case "network-app-proxy":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPointIdentifier: "com.apple.networkextension.app-proxy",
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).AppProxyProvider",
+        },
+      });
+    case "network-dns-proxy":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPointIdentifier: "com.apple.networkextension.dns-proxy",
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).DNSProxyProvider",
+        },
+      });
+    case "network-filter-data":
+      return plist.build({
+        NSExtension: {
+          NSExtensionPointIdentifier: "com.apple.networkextension.filter-data",
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).FilterDataProvider",
+        },
+      });
+    default: 
+      // Default: used for widget and bg-download
+      return plist.build({
+        NSExtension: {
+          NSExtensionPointIdentifier,
+        },
+      });
   }
-
-  // Default: used for widget and bg-download
-  return plist.build({
-    NSExtension: {
-      NSExtensionPointIdentifier,
-    },
-  });
 }
 
 export function productTypeForType(type: ExtensionType) {
@@ -317,6 +354,10 @@ export function needsEmbeddedSwift(type: ExtensionType) {
     "quicklook-thumbnail",
     "matter",
     "clip",
+    "network-packet-tunnel",
+    "network-app-proxy",
+    "network-dns-proxy",
+    "network-filter-data",
   ].includes(type);
 }
 
@@ -346,6 +387,11 @@ export function getFrameworksForType(type: ExtensionType) {
     return [
       // "UniformTypeIdentifiers"
     ];
+  } else if (
+    ["network-packet-tunnel", "network-app-proxy",
+      "network-dns-proxy", "network-filter-data"].includes(type)
+  ) {
+    return ["NetworkExtension"];
   }
 
   return [];
@@ -386,11 +432,10 @@ export function isNativeTargetOfType(
     return false;
   }
 
-  return (
-    KNOWN_EXTENSION_POINT_IDENTIFIERS[
-      infoPlist.NSExtension?.NSExtensionPointIdentifier
-    ] === type
-  );
+  const identifier = infoPlist.NSExtension.NSExtensionPointIdentifier;
+  const mappedType = KNOWN_EXTENSION_POINT_IDENTIFIERS[identifier];
+
+  return mappedType === type;
 }
 
 export function getMainAppTarget(project: XcodeProject): PBXNativeTarget {

--- a/packages/create-target/src/promptTarget.ts
+++ b/packages/create-target/src/promptTarget.ts
@@ -38,6 +38,26 @@ export const TARGETS = [
   { title: "Location Push", value: "location-push", description: "" },
   { title: "Matter", value: "matter", description: "" },
   {
+    title: "Network Extension: Packet Tunnel Provider",
+    value: "network-packet-tunnel",
+    description: "",
+  },
+  {
+    title: "Network Extension: App Proxy",
+    value: "network-app-proxy",
+    description: "",
+  },
+  {
+    title: "Network Extension: DNS Proxy",
+    value: "network-dns-proxy",
+    description: "",
+  },
+  {
+    title: "Network Extension: Filter Data",
+    value: "network-filter-data",
+    description: "",
+  },
+  {
     title: "Notification Content",
     value: "notification-content",
     description: "",

--- a/packages/create-target/templates/network-app-proxy/AppProxyProvider.swift
+++ b/packages/create-target/templates/network-app-proxy/AppProxyProvider.swift
@@ -1,0 +1,34 @@
+import NetworkExtension
+
+class AppProxyProvider: NEAppProxyProvider {
+
+    override func startProxy(options: [String : Any]? = nil, completionHandler: @escaping (Error?) -> Void) {
+        // Add code here to start the process of connecting the tunnel.
+    }
+    
+    override func stopProxy(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        // Add code here to start the process of stopping the tunnel.
+        completionHandler()
+    }
+    
+    override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
+        // Add code here to handle the message.
+        if let handler = completionHandler {
+            handler(messageData)
+        }
+    }
+    
+    override func sleep(completionHandler: @escaping() -> Void) {
+        // Add code here to get ready to sleep.
+        completionHandler()
+    }
+    
+    override func wake() {
+        // Add code here to wake up.
+    }
+    
+    override func handleNewFlow(_ flow: NEAppProxyFlow) -> Bool {
+        // Add code here to handle the incoming flow.
+        return false
+    }
+}

--- a/packages/create-target/templates/network-dns-proxy/DNSProxyProvider.swift
+++ b/packages/create-target/templates/network-dns-proxy/DNSProxyProvider.swift
@@ -1,0 +1,29 @@
+import NetworkExtension
+
+class DNSProxyProvider: NEDNSProxyProvider {
+
+    override func startProxy(options:[String: Any]? = nil, completionHandler: @escaping (Error?) -> Void) {
+        // Add code here to start the DNS proxy.
+        completionHandler(nil)
+    }
+
+    override func stopProxy(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        // Add code here to stop the DNS proxy.
+        completionHandler()
+    }
+
+    override func sleep(completionHandler: @escaping () -> Void) {
+        // Add code here to get ready to sleep.
+        completionHandler()
+    }
+
+    override func wake() {
+        // Add code here to wake up.
+    }
+
+    override func handleNewFlow(_ flow: NEAppProxyFlow) -> Bool {
+        // Add code here to handle the incoming flow.
+        return false
+    }
+
+}

--- a/packages/create-target/templates/network-filter-data/FilterDataProvider.swift
+++ b/packages/create-target/templates/network-filter-data/FilterDataProvider.swift
@@ -1,0 +1,19 @@
+import NetworkExtension
+
+class FilterDataProvider: NEFilterDataProvider {
+
+    override func startFilter(completionHandler: @escaping (Error?) -> Void) {
+        // Add code to initialize the filter.
+        completionHandler(nil)
+    }
+    
+    override func stopFilter(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        // Add code to clean up filter resources.
+        completionHandler()
+    }
+    
+    override func handleNewFlow(_ flow: NEFilterFlow) -> NEFilterNewFlowVerdict {
+        // Add code to determine if the flow should be dropped or not, downloading new rules if required.
+        return .allow()
+    }
+}

--- a/packages/create-target/templates/network-packet-tunnel/PacketTunnelProvider.swift
+++ b/packages/create-target/templates/network-packet-tunnel/PacketTunnelProvider.swift
@@ -1,0 +1,29 @@
+import NetworkExtension
+
+class PacketTunnelProvider: NEPacketTunnelProvider {
+
+    override func startTunnel(options: [String : NSObject]?, completionHandler: @escaping (Error?) -> Void) {
+        // Add code here to start the process of connecting the tunnel.
+    }
+    
+    override func stopTunnel(with reason: NEProviderStopReason, completionHandler: @escaping () -> Void) {
+        // Add code here to start the process of stopping the tunnel.
+        completionHandler()
+    }
+    
+    override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?) {
+        // Add code here to handle the message.
+        if let handler = completionHandler {
+            handler(messageData)
+        }
+    }
+    
+    override func sleep(completionHandler: @escaping () -> Void) {
+        // Add code here to get ready to sleep.
+        completionHandler()
+    }
+    
+    override func wake() {
+        // Add code here to wake up.
+    }
+}


### PR DESCRIPTION
# Motivation

I came across this config plugin while looking for solutions for Expo iOS widget development, and maintaining network-related Expo apps on iOS, I felt it could be a nice improvement to also support the different Network Extensions types. 

# Execution

1. Added the new targets into the prompt system.
2. Extended ActionType, KNOWN_EXTENSION_POINT_IDENTIFIERS, SHOULD_USE_APP_GROUPS_BY_DEFAULT, productTypeForType, getFrameworksForType to support the network extensions.
3. Added templates as provided by xCode for the different network extensions.
4. Bonus: Replaced the main "if" / "elseif" / ... block by a switch.

