### PR TITLE
add a name argument to the widget

### DIFF
--- a/packages/create-target/src/cli.ts
+++ b/packages/create-target/src/cli.ts
@@ -17,7 +17,8 @@ const debug = require("debug")("expo:create-target") as typeof console.log;
 // pick type of target
 // find-up expo project
 // `npx expo install @bacons/apple-targets`
-// create `/targets/<name>` directory
+// create `/targets/<name>` directory. If the --name argument is passed,
+// that becomes the name, else, use the target name
 // add expo-target.config.js file
 // inject some template files.
 // Log about needing to re-run prebuild.
@@ -26,11 +27,13 @@ async function run() {
   const argv = process.argv.slice(2) ?? [];
   const rawArgsMap: Spec = {
     // Types
+    "--name": String,
     "--no-install": Boolean,
     "--help": Boolean,
     "--version": Boolean,
     // Aliases
     "-h": "--help",
+    "-n": "--name",
     "-v": "--version",
   };
   const args = assertWithOptionsArgs(rawArgsMap, {
@@ -46,8 +49,9 @@ async function run() {
     const nameWithoutCreate = CLI_NAME.replace("create-", "");
     printHelp(
       `Creates a new Expo Apple target`,
-      chalk`npx ${CLI_NAME} {cyan <target>} [options]`,
+      chalk`npx ${CLI_NAME} {cyan <target>} [--name <name>] [options]`,
       [
+        `-n, --name <name>     Custom name for the target directory`,
         `    --no-install      Skip installing npm packages`,
         `-v, --version         Version number`,
         `-h, --help            Usage info`,
@@ -71,12 +75,14 @@ async function run() {
     debug(`Parsed:\n%O`, parsed);
 
     const { createAsync } = await import("./createAsync");
+    const name = parsed.args["--name"] as string | undefined;
     await createAsync(
       // This is the target
       parsed.projectRoot,
       {
         install: !args["--no-install"],
-      }
+        name,
+      },
     );
   } catch (error: any) {
     // ExitError has already been logged, all others should be logged before exiting.

--- a/packages/create-target/src/createAsync.ts
+++ b/packages/create-target/src/createAsync.ts
@@ -21,6 +21,7 @@ import spawnAsync from "@expo/spawn-async";
 
 export type Options = {
   install: boolean;
+  name?: string;
 };
 
 function getNamedPlugins(
@@ -104,7 +105,11 @@ export async function createAsync(
     resolvedTarget = await promptTargetAsync();
   } else {
     resolvedTarget = target;
-    console.log(chalk`Creating a {cyan ${resolvedTarget}} Apple target.\n`);
+    if (props.name) {
+      console.log(chalk`Creating a {cyan ${resolvedTarget}} Apple target named {cyan ${props.name}}.\n`);
+    } else {
+      console.log(chalk`Creating a {cyan ${resolvedTarget}} Apple target.\n`);
+    }
   }
 
   if (!resolvedTarget) {
@@ -112,7 +117,8 @@ export async function createAsync(
   }
   assertValidTarget(resolvedTarget);
 
-  const targetDir = path.join(projectRoot, "targets", resolvedTarget);
+  const targetName = props.name || resolvedTarget;
+  const targetDir = path.join(projectRoot, "targets", targetName);
 
   if (fs.existsSync(targetDir)) {
     // Check if the target directory is empty


### PR DESCRIPTION
# Summary

Adds support for a `--name` (or `-n`) argument to the `create-target` CLI, allowing developers to specify a custom name for the target directory. This enables creating multiple targets of the same type within a single project. Practical use cases may be:
- Multiple widgets with different purposes (home screen widget, lock screen widget, etc.)
- Multiple app clips for different experiences
- Multiple share extensions with different configurations

# Motivation

Previously, the CLI would create a target directory using the target type as the directory name (e.g., `targets/widget/`). This meant you could only have one target of each type per project. An attempt to create another of the same target requested that we overwrite what already existed.

In most cases where multiple of the same target, we had to manually override the target before proceeding.

# Execution

## Manual testing performed

### 1. Help Output Verification
```bash
$ node build/index.js --help

Info
    Creates a new Expo Apple target

  Usage
    $ npx create-target <target> [--name <name>] [options]

  Options
    -n, --name <name>     Custom name for the target directory
        --no-install      Skip installing npm packages
    -v, --version         Version number
    -h, --help            Usage info
```
- [x] Help text correctly displays the new `--name` option

### 2. TypeScript Compilation
```bash
$ yarn build
```
- [x] No TypeScript errors
- [x] Build succeeds and bundles correctly

### 3. Argument Parsing
- [x] Verified `--name` flag is parsed correctly
- [x] Verified `-n` short alias works
- [x] Verified name is passed to `createAsync()` function

### 4. Directory Creation Logic
- [x] Confirmed `targetName = props.name || resolvedTarget` fallback logic
- [x] Verified console output shows custom name when provided
- [x] Tested backward compatibility (without `--name` argument)

# Test Plan

Creating multiple widget targets:

```bash
npx create-target widget --name home-widget
npx create-target widget -n lock-widget
npx create-target widget --name standby-widget
```