### PR TITLE
feat: keyboard target support

### DIFF
--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -21,7 +21,8 @@ export type ExtensionType =
   | "action"
   | "safari"
   | "app-intent"
-  | "device-activity-monitor";
+  | "device-activity-monitor"
+  | "keyboard";
 
 export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =
   {
@@ -45,6 +46,7 @@ export const KNOWN_EXTENSION_POINT_IDENTIFIERS: Record<string, ExtensionType> =
     "com.apple.services": "action",
     "com.apple.appintents-extension": "app-intent",
     "com.apple.deviceactivity.monitor-extension": "device-activity-monitor",
+    "com.apple.keyboard-service": "keyboard",
     // "com.apple.intents-service": "intents",
   };
 
@@ -56,6 +58,7 @@ export const SHOULD_USE_APP_GROUPS_BY_DEFAULT: Record<ExtensionType, boolean> =
     "bg-download": true,
     clip: true,
     widget: true,
+    keyboard: true,
     "account-auth": false,
     "credentials-provider": false,
     "device-activity-monitor": false,
@@ -278,6 +281,20 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
         NSExtensionPointIdentifier,
       },
     });
+  } else if (type === "keyboard") {
+    return plist.build({
+      NSExtension: {
+        NSExtensionPointIdentifier,
+        NSExtensionPrincipalClass:
+          "$(PRODUCT_MODULE_NAME).KeyboardViewController",
+        NSExtensionAttributes: {
+          RequestsOpenAccess: false,
+          IsASCIICapable: false,
+          PrefersRightToLeft: false,
+          PrimaryLanguage: "en-US",
+        },
+      },
+    });
   }
 
   // Default: used for widget and bg-download
@@ -312,6 +329,7 @@ export function needsEmbeddedSwift(type: ExtensionType) {
     "quicklook-thumbnail",
     "matter",
     "clip",
+    "keyboard",
   ].includes(type);
 }
 

--- a/packages/apple-targets/src/template/XCBuildConfiguration.json
+++ b/packages/apple-targets/src/template/XCBuildConfiguration.json
@@ -755,5 +755,42 @@
         "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).ActionRequestHandler"
       }
     }
+  },
+  "com.apple.keyboard-service": {
+    "default": {
+      "CODE_SIGN_STYLE": "Automatic",
+      "CURRENT_PROJECT_VERSION": 1,
+      "DEVELOPMENT_TEAM": "QQ57RJ5UTD",
+      "GENERATE_INFOPLIST_FILE": "YES",
+      "INFOPLIST_FILE": "../targets/keyboard/Info.plist",
+      "INFOPLIST_KEY_CFBundleDisplayName": "keyboard",
+      "INFOPLIST_KEY_NSHumanReadableCopyright": "",
+      "IPHONEOS_DEPLOYMENT_TARGET": 18.0,
+      "LD_RUNPATH_SEARCH_PATHS": "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks",
+      "MARKETING_VERSION": 1,
+      "PRODUCT_BUNDLE_IDENTIFIER": "com.bacon.2095.keyboard",
+      "PRODUCT_NAME": "$(TARGET_NAME)",
+      "SDKROOT": "iphoneos",
+      "SKIP_INSTALL": "YES",
+      "STRING_CATALOG_GENERATE_SYMBOLS": "YES",
+      "SWIFT_APPROACHABLE_CONCURRENCY": "YES",
+      "SWIFT_EMIT_LOC_STRINGS": "YES",
+      "SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY": "YES",
+      "SWIFT_VERSION": "5.0",
+      "TARGETED_DEVICE_FAMILY": "1,2"
+    },
+    "release": {
+      "VALIDATE_PRODUCT": "YES"
+    },
+    "debug": {},
+    "info": {
+      "NSExtension": {
+        "NSExtensionPointIdentifier": "com.apple.keyboard-service",
+        "NSExtensionPrincipalClass": "$(PRODUCT_MODULE_NAME).KeyboardViewController",
+        "NSExtensionAttributes": {
+          "RequestsOpenAccess": true
+        }
+      }
+    }
   }
 }

--- a/packages/apple-targets/src/withXcodeChanges.ts
+++ b/packages/apple-targets/src/withXcodeChanges.ts
@@ -879,6 +879,69 @@ function createWidgetConfigurationList(
   return configurationList;
 }
 
+function createKeyboardConfigurationList(
+  project: XcodeProject,
+  {
+    name,
+    displayName,
+    cwd,
+    bundleId,
+    deploymentTarget,
+    currentProjectVersion,
+  }: XcodeSettings
+) {
+  const common: BuildSettings = {
+    CODE_SIGN_STYLE: "Automatic",
+    CURRENT_PROJECT_VERSION: currentProjectVersion,
+    GENERATE_INFOPLIST_FILE: "YES",
+    INFOPLIST_FILE: cwd + "/Info.plist",
+    INFOPLIST_KEY_CFBundleDisplayName: displayName ?? name,
+    INFOPLIST_KEY_NSHumanReadableCopyright: "",
+    IPHONEOS_DEPLOYMENT_TARGET: deploymentTarget,
+    LD_RUNPATH_SEARCH_PATHS: [
+      "$(inherited)",
+      "@executable_path/Frameworks",
+      "@executable_path/../../Frameworks",
+    ],
+    MARKETING_VERSION: "1.0",
+    PRODUCT_BUNDLE_IDENTIFIER: bundleId,
+    PRODUCT_NAME: "$(TARGET_NAME)",
+    SDKROOT: "iphoneos",
+    SKIP_INSTALL: "YES",
+    // @ts-expect-error - New Xcode build settings not in types yet
+    STRING_CATALOG_GENERATE_SYMBOLS: "YES",
+    SWIFT_APPROACHABLE_CONCURRENCY: "YES",
+    SWIFT_EMIT_LOC_STRINGS: "YES",
+    SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY: "YES",
+    SWIFT_VERSION: "5.0",
+    TARGETED_DEVICE_FAMILY: "1,2",
+  };
+
+  const debugBuildConfig = XCBuildConfiguration.create(project, {
+    name: "Debug",
+    buildSettings: {
+      ...common,
+    },
+  });
+
+  const releaseBuildConfig = XCBuildConfiguration.create(project, {
+    name: "Release",
+    buildSettings: {
+      ...common,
+      // Diff
+      VALIDATE_PRODUCT: "YES",
+    },
+  });
+
+  const configurationList = XCConfigurationList.create(project, {
+    buildConfigurations: [debugBuildConfig, releaseBuildConfig],
+    defaultConfigurationIsVisible: 0,
+    defaultConfigurationName: "Release",
+  });
+
+  return configurationList;
+}
+
 function createConfigurationListForType(
   project: XcodeProject,
   props: XcodeSettings
@@ -891,6 +954,8 @@ function createConfigurationListForType(
       "com.apple.services",
       props
     );
+  } else if (props.type === "keyboard") {
+    return createKeyboardConfigurationList(project, props);
   } else if (props.type === "share") {
     return createShareConfigurationList(project, props);
   } else if (props.type === "safari") {

--- a/packages/create-target/src/promptTarget.ts
+++ b/packages/create-target/src/promptTarget.ts
@@ -35,6 +35,11 @@ export const TARGETS = [
     value: "device-activity-monitor",
     description: "",
   },
+  {
+    title: "Keyboard Extension",
+    value: "keyboard",
+    description: "Custom system keyboard",
+  },
   { title: "Location Push", value: "location-push", description: "" },
   { title: "Matter", value: "matter", description: "" },
   {

--- a/packages/create-target/templates/keyboard/KeyboardViewController.swift
+++ b/packages/create-target/templates/keyboard/KeyboardViewController.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+class KeyboardViewController: UIInputViewController {
+
+    @IBOutlet var nextKeyboardButton: UIButton!
+
+    override func updateViewConstraints() {
+        super.updateViewConstraints()
+
+        // Add custom view sizing constraints here
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Perform custom UI setup here
+        self.nextKeyboardButton = UIButton(type: .system)
+
+        self.nextKeyboardButton.setTitle(NSLocalizedString("Next Keyboard", comment: "Title for 'Next Keyboard' button"), for: [])
+        self.nextKeyboardButton.sizeToFit()
+        self.nextKeyboardButton.translatesAutoresizingMaskIntoConstraints = false
+
+        self.nextKeyboardButton.addTarget(self, action: #selector(handleInputModeList(from:with:)), for: .allTouchEvents)
+
+        self.view.addSubview(self.nextKeyboardButton)
+
+        self.nextKeyboardButton.leftAnchor.constraint(equalTo: self.view.leftAnchor).isActive = true
+        self.nextKeyboardButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor).isActive = true
+    }
+
+    override func viewWillLayoutSubviews() {
+        self.nextKeyboardButton.isHidden = !self.needsInputModeSwitchKey
+        super.viewWillLayoutSubviews()
+    }
+
+    override func textWillChange(_ textInput: UITextInput?) {
+        // The app is about to change the document's contents. Perform any preparation here.
+    }
+
+    override func textDidChange(_ textInput: UITextInput?) {
+        // The app has just changed the document's contents, the document context has been updated.
+
+        var textColor: UIColor
+        let proxy = self.textDocumentProxy
+        if proxy.keyboardAppearance == UIKeyboardAppearance.dark {
+            textColor = UIColor.white
+        } else {
+            textColor = UIColor.black
+        }
+        self.nextKeyboardButton.setTitleColor(textColor, for: [])
+    }
+
+}


### PR DESCRIPTION
# Motivation

Add support for creating custom keyboard targets. These are pretty gnarly to build, but this ensures the framework is in place to get started.
