### PR TITLE
[feat] add shared container url

### DIFF
--- a/packages/apple-targets/ios/ExtensionStorageModule.swift
+++ b/packages/apple-targets/ios/ExtensionStorageModule.swift
@@ -67,15 +67,23 @@ public class ExtensionStorageModule: Module {
                     let jsonObject = try JSONSerialization.jsonObject(with: data, options: [])
                     let jsonData = try JSONSerialization.data(withJSONObject: jsonObject, options: [.prettyPrinted])
                     return String(data: jsonData, encoding: .utf8)
-                } catch {                    
+                } catch {
                     return nil
                 }
             }
-            
+
             if let value = userDefaults?.object(forKey: key) {
                 return String(describing: value)
             }
             return nil
+        }
+
+        Function("getSharedContainerURL") { (group: String?) -> String? in
+            guard let group = group else {
+                return nil
+            }
+            let containerURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: group)
+            return containerURL?.path
         }
     }
 }

--- a/packages/apple-targets/src/ExtensionStorage.ts
+++ b/packages/apple-targets/src/ExtensionStorage.ts
@@ -15,6 +15,7 @@ type NativeModule = {
     suite?: string
   ): boolean;
   get(key: string, suite?: string): string | null;
+  getSharedContainerURL(appGroup: string): string | null;
 };
 
 // @ts-expect-error
@@ -29,6 +30,7 @@ const nativeModule: NativeModule = ExtensionStorageModule ?? {
   setArray() {},
   get() {},
   remove() {},
+  getSharedContainerURL() { return null; },
 };
 
 const originalSetObject = nativeModule.setObject;
@@ -54,7 +56,15 @@ export class ExtensionStorage {
     nativeModule.reloadControls(name);
   }
 
+  static getSharedContainerURL(appGroup: string): string | null {
+    return nativeModule.getSharedContainerURL(appGroup);
+  }
+
   constructor(private readonly appGroup: string) {}
+
+  getContainerURL(): string | null {
+    return nativeModule.getSharedContainerURL(this.appGroup);
+  }
 
   set(
     key: string,


### PR DESCRIPTION
## Summary

Add support for retrieving shared container URLs for app groups. This enables accessing files shared between the main app and extensions like widgets. In production (TestFlight + App Store), widgets made with `expo-apple-targets` unfortunately cannot access the app's [file system](https://docs.expo.dev/versions/latest/sdk/filesystem/) and are sandboxed to sharing file data in the app group shared container.

## Key Use Case

Saving references to files (photos, documents) from the main app and accessing them from widgets by using the shared container path to construct full file URLs.

## Changes

  - Added `getSharedContainerURL(appGroup: string)` static method to get container URL for any app group
  - Added `getContainerURL()` instance method to get container URL for the configured app group
  - Implemented native iOS method using `FileManager.default.containerURL(forSecurityApplicationGroupIdentifier:)`

## Usage

  ```typescript
  import { ExtensionStorage } from '@bacons/apple-targets';

  // Static method
  const containerURL = ExtensionStorage.getSharedContainerURL('group.com.example.app');

  // Instance method
  const storage = new ExtensionStorage('group.com.example.app');
  const url = storage.getContainerURL();
  // e.g., "/var/mobile/Containers/Shared/AppGroup/..."
```

## Test Plan

  - Verify methods return correct path for valid app groups
  - Test file access between app and widget using returned path
  - Verify returns null for invalid app groups