### PR TITLE
fix(widget): add ASSETCATALOG_COMPILER_APPICON_NAME when icon is provided

### DIFF
--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -640,6 +640,8 @@ function createWidgetConfigurationList({
     debug: {
       ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: "$accent",
       ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: "$widgetBackground",
+      // Add app icon name when icon is provided to prevent inheriting main app's icon setting
+      ...(icon && { ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon" }),
       CLANG_ANALYZER_NONNULL: "YES",
       CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
       CLANG_CXX_LANGUAGE_STANDARD: "gnu++20",
@@ -676,6 +678,8 @@ function createWidgetConfigurationList({
     release: {
       ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: "$accent",
       ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: "$widgetBackground",
+      // Add app icon name when icon is provided to prevent inheriting main app's icon setting
+      ...(icon && { ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon" }),
       CLANG_ANALYZER_NONNULL: "YES",
       CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
       CLANG_CXX_LANGUAGE_STANDARD: "gnu++20",


### PR DESCRIPTION
## Summary

The `createWidgetConfigurationList` function accepts an `icon` parameter but doesn't use it to set `ASSETCATALOG_COMPILER_APPICON_NAME`. This causes widget targets to inherit the main app's icon setting (e.g., liquid glass icons on iOS 26), resulting in build errors like:

```
None of the input catalogs contained a matching stickers icon set,
app icon set, or icon stack named "icon-ios-liquid-glass"
```

## Changes

- Added conditional `ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon"` to both debug and release configurations in `createWidgetConfigurationList` when `icon` is provided
- Follows the same pattern used in `createActionConfigurationList` (lines 157-159)

## Test Plan

1. Create a project with a liquid glass icon (iOS 26) in `app.json`:
   ```json
   "ios": {
     "icon": "./assets/icon-ios-liquid-glass.icon"
   }
   ```
2. Add a widget target with an icon in `expo-target.config.js`:
   ```js
   module.exports = (config) => ({
     type: "widget",
     icon: "../../assets/images/icon.png",
     // ...
   });
   ```
3. Run `npx expo prebuild -p ios --clean`
4. Build the widget target in Xcode
5. Verify no asset catalog errors about missing icon

Without this fix, the widget target inherits `ASSETCATALOG_COMPILER_APPICON_NAME = "icon-ios-liquid-glass"` from the project-level settings and fails to build.