### PR TITLE
fix: set ASSETCATALOG_COMPILER_APPICON_NAME for Safari and Widget targets

### DIFF
--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -431,8 +431,10 @@ function createSafariConfigurationList({
   bundleId,
   deploymentTarget,
   currentProjectVersion,
+  icon,
 }: XcodeSettings): { debug: BuildSettings; release: BuildSettings } {
   const common: BuildSettings = {
+    ...(icon && { ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon" }),
     CLANG_ANALYZER_NONNULL: "YES",
     CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: "YES_AGGRESSIVE",
     CLANG_CXX_LANGUAGE_STANDARD: "gnu++20",
@@ -638,6 +640,7 @@ function createWidgetConfigurationList({
 }: XcodeSettings): { debug: BuildSettings; release: BuildSettings } {
   return {
     debug: {
+      ...(icon && { ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon" }),
       ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: "$accent",
       ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: "$widgetBackground",
       CLANG_ANALYZER_NONNULL: "YES",
@@ -674,6 +677,7 @@ function createWidgetConfigurationList({
       TARGETED_DEVICE_FAMILY: "1,2",
     },
     release: {
+      ...(icon && { ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon" }),
       ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: "$accent",
       ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME: "$widgetBackground",
       CLANG_ANALYZER_NONNULL: "YES",


### PR DESCRIPTION
# Motivation

When the main app uses a `.icon` icon (e.g., `glass.icon` for iOS 26 liquid glass icons), Expo sets `ASSETCATALOG_COMPILER_APPICON_NAME` to the folder name (e.g., "glass"). Safari extension targets that don't explicitly set this build setting inherit it from the main app, causing build failures:

This causes build failured because the plugin generates icons in `AppIcon.appiconset`, but the build expects `glass.appiconset`.

#157 fixes this for Widget targets but this PR also adds the same fix for Safari targets.

Credit to [fredrikburmester](https://github.com/EvanBacon/expo-apple-targets/commits?author=fredrikburmester) for the Widget fix 🙏 (added you as a co-author, hope you dont mind!)

# Execution

Added the same pattern from #157 to `createSafariConfigurationList` - explicitly setting
`ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon"` when an icon is provided:

 ```typescript
  ...(icon && { ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon" }),
```

 # Test Plan

  1. Create an Expo app with glass.icon set to a .icon folder (e.g., glass.icon)
  2. Add a Safari extension/widget target with an icon configured
  3. Run `npx expo prebuild -p ios --clean`
  4. Build the project

  Before: Build fails with missing icon set error
  After: Build succeeds with Safari target using AppIcon and the main app using a liquid glass icon
