### PR TITLE
feat(targets): add file-provider, broadcast-upload, call-directory, message-filter

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -309,6 +309,10 @@ Ideally, this would be generated automatically based on a fully qualified Xcode 
 | network-dns-proxy       | DNS Proxy Network Extension        |
 | network-filter-data     | Filter Data Network Extension      |
 | content-blocker         | Safari Content Blocker Extension   |
+| file-provider           | File Provider Extension            |
+| broadcast-upload        | Broadcast Upload Extension         |
+| call-directory          | Call Directory Extension           |
+| message-filter          | Message Filter Extension           |
 
 
 <!-- | imessage             | iMessage Extension               | -->
@@ -319,13 +323,9 @@ The following iOS extension types exist in Xcode but aren't supported yet. Contr
 
 | Extension Point Identifier | Xcode Template Name |
 | --- | --- |
-| `com.apple.fileprovider-nonui` | File Provider Extension |
 | `com.apple.fileprovider-actionsui` | File Provider UI Extension |
-| `com.apple.broadcast-services-upload` | Broadcast Upload Extension |
 | `com.apple.broadcast-services-setupui` | Broadcast Setup UI Extension |
-| `com.apple.callkit.call-directory` | Call Directory Extension |
 | `com.apple.classkit.context-provider` | ClassKit Context Provider Extension |
-| `com.apple.identitylookup.message-filter` | Message Filter Extension |
 | `com.apple.identitylookup.classification-ui` | Unwanted Communication Reporting Extension |
 | `com.apple.photo-editing` | Photo Editing Extension |
 | `com.apple.printing.discovery` | Print Service Extension |

--- a/packages/apple-targets/e2e/__tests__/build.test.ts
+++ b/packages/apple-targets/e2e/__tests__/build.test.ts
@@ -97,6 +97,14 @@ const TARGET_REGISTRY: TargetEntry[] = [
       "Watch target requires AppIcon asset catalog which is not generated without an icon config",
   },
   { type: "widget", dir: "widget", target: "widget" },
+  { type: "file-provider", dir: "file-provider", target: "fileprovider" },
+  {
+    type: "broadcast-upload",
+    dir: "broadcast-upload",
+    target: "broadcastupload",
+  },
+  { type: "call-directory", dir: "call-directory", target: "calldirectory" },
+  { type: "message-filter", dir: "message-filter", target: "messagefilter" },
 ];
 
 // Derived from the central TARGET_REGISTRY — no need to maintain by hand.

--- a/packages/apple-targets/e2e/fixture/targets/broadcast-upload/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/broadcast-upload/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "broadcast-upload" }

--- a/packages/apple-targets/e2e/fixture/targets/call-directory/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/call-directory/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "call-directory" }

--- a/packages/apple-targets/e2e/fixture/targets/file-provider/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/file-provider/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "file-provider" }

--- a/packages/apple-targets/e2e/fixture/targets/message-filter/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/message-filter/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "message-filter" }

--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -804,6 +804,10 @@ function getConfigurationListBuildSettingsForType(
     case "quicklook-thumbnail":
     case "spotlight":
     case "content-blocker":
+    case "file-provider":
+    case "broadcast-upload":
+    case "call-directory":
+    case "message-filter":
       return createNotificationContentConfigurationList(props);
     default:
       const exhaustiveCheck: never = props.type;

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -170,6 +170,27 @@ export const TARGET_REGISTRY = {
     displayName: "Content Blocker",
     description: "Safari content blocker extension",
   },
+  "file-provider": {
+    extensionPointIdentifier: "com.apple.fileprovider-nonui",
+    frameworks: ["UniformTypeIdentifiers"],
+    appGroupsByDefault: true,
+    displayName: "File Provider",
+  },
+  "broadcast-upload": {
+    extensionPointIdentifier: "com.apple.broadcast-services-upload",
+    frameworks: ["ReplayKit"],
+    displayName: "Broadcast Upload",
+  },
+  "call-directory": {
+    extensionPointIdentifier: "com.apple.callkit.call-directory",
+    frameworks: ["CallKit"],
+    displayName: "Call Directory",
+  },
+  "message-filter": {
+    extensionPointIdentifier: "com.apple.identitylookup.message-filter",
+    frameworks: ["IdentityLookup"],
+    displayName: "Message Filter",
+  },
 } as const satisfies Record<string, TargetDefinition>;
 
 export type ExtensionType = keyof typeof TARGET_REGISTRY;
@@ -472,6 +493,39 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
           NSExtensionPointIdentifier: "com.apple.networkextension.filter-data",
           NSExtensionPrincipalClass:
             "$(PRODUCT_MODULE_NAME).FilterDataProvider",
+        },
+      };
+    case "file-provider":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).FileProviderExtension",
+          NSExtensionFileProviderSupportsEnumeration: true,
+        },
+      };
+    case "broadcast-upload":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).SampleHandler",
+          RPBroadcastProcessMode: "RPBroadcastProcessModeSampleBuffer",
+        },
+      };
+    case "call-directory":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).CallDirectoryHandler",
+        },
+      };
+    case "message-filter":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).MessageFilterExtension",
         },
       };
     default:

--- a/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
+++ b/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
@@ -34,6 +34,22 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for broadcast-upload 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"broadcast-upload\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
+exports[`getTemplateConfig should return a valid template for call-directory 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"call-directory\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for clip 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
@@ -59,6 +75,14 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for file-provider 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"file-provider\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for intent 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
@@ -79,6 +103,14 @@ exports[`getTemplateConfig should return a valid template for location-push 1`] 
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
   type: \\"location-push\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
+exports[`getTemplateConfig should return a valid template for message-filter 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"message-filter\\",
   entitlements: { /* Add entitlements */ },
 });"
 `;

--- a/packages/create-target/src/__tests__/createAsync.test.ts
+++ b/packages/create-target/src/__tests__/createAsync.test.ts
@@ -19,6 +19,10 @@ const ALL_TARGET_TYPES = [
   "credentials-provider",
   "account-auth",
   "device-activity-monitor",
+  "file-provider",
+  "broadcast-upload",
+  "call-directory",
+  "message-filter",
 ];
 
 describe(getTemplateConfig, () => {

--- a/packages/create-target/templates/broadcast-upload/SampleHandler.swift
+++ b/packages/create-target/templates/broadcast-upload/SampleHandler.swift
@@ -1,0 +1,37 @@
+import ReplayKit
+
+class SampleHandler: RPBroadcastSampleHandler {
+
+    override func broadcastStarted(withSetupInfo setupInfo: [String : NSObject]?) {
+        // User has requested to start the broadcast. Setup info from the UI extension can be supplied but optional.
+    }
+
+    override func broadcastPaused() {
+        // User has requested to pause the broadcast. Samples will stop being delivered.
+    }
+
+    override func broadcastResumed() {
+        // User has requested to resume the broadcast. Samples delivery will resume.
+    }
+
+    override func broadcastFinished() {
+        // User has requested to finish the broadcast.
+    }
+
+    override func processSampleBuffer(_ sampleBuffer: CMSampleBuffer, with sampleBufferType: RPSampleBufferType) {
+        switch sampleBufferType {
+        case RPSampleBufferType.video:
+            // Handle video sample buffer
+            break
+        case RPSampleBufferType.audioApp:
+            // Handle audio sample buffer for app audio
+            break
+        case RPSampleBufferType.audioMic:
+            // Handle audio sample buffer for mic audio
+            break
+        @unknown default:
+            // Handle other sample buffer types
+            fatalError("Unknown type of sample buffer")
+        }
+    }
+}

--- a/packages/create-target/templates/call-directory/CallDirectoryHandler.swift
+++ b/packages/create-target/templates/call-directory/CallDirectoryHandler.swift
@@ -1,0 +1,64 @@
+import Foundation
+import CallKit
+
+class CallDirectoryHandler: CXCallDirectoryProvider {
+
+    override func beginRequest(with context: CXCallDirectoryExtensionContext) {
+        context.delegate = self
+
+        // Check whether this is an "incremental" data request. If so, only provide the set of phone number blocking
+        // and identification entries which have been added or removed since the last time this extension's data was loaded.
+        // But the first time this is called, you must provide the full set of data.
+        if context.isIncremental {
+            addOrRemoveIncrementalBlockingPhoneNumbers(to: context)
+            addOrRemoveIncrementalIdentificationPhoneNumbers(to: context)
+        } else {
+            addAllBlockingPhoneNumbers(to: context)
+            addAllIdentificationPhoneNumbers(to: context)
+        }
+
+        context.completeRequest()
+    }
+
+    private func addAllBlockingPhoneNumbers(to context: CXCallDirectoryExtensionContext) {
+        // Retrieve all phone numbers to block from data store. For optimal performance and target
+        // having a responsive user interface, consider only loading a subset of numbers at a given time
+        // and using autoreleasepools to release objects allocated during each batch of numbers which are loaded.
+        //
+        // Numbers must be provided in numerically ascending order.
+        let allPhoneNumbers: [CXCallDirectoryPhoneNumber] = [ 1_408_555_5555, 1_800_555_5555 ]
+        for phoneNumber in allPhoneNumbers {
+            context.addBlockingEntry(withNextSequentialPhoneNumber: phoneNumber)
+        }
+    }
+
+    private func addOrRemoveIncrementalBlockingPhoneNumbers(to context: CXCallDirectoryExtensionContext) {
+        // Retrieve any changes to the set of phone numbers to block from data store.
+    }
+
+    private func addAllIdentificationPhoneNumbers(to context: CXCallDirectoryExtensionContext) {
+        // Retrieve phone numbers to identify and their identification labels from data store.
+        //
+        // Numbers must be provided in numerically ascending order.
+        let allPhoneNumbers: [CXCallDirectoryPhoneNumber] = [ 1_877_555_5555, 1_888_555_5555 ]
+        let labels = [ "Telemarketer", "Local business" ]
+
+        for (phoneNumber, label) in zip(allPhoneNumbers, labels) {
+            context.addIdentificationEntry(withNextSequentialPhoneNumber: phoneNumber, label: label)
+        }
+    }
+
+    private func addOrRemoveIncrementalIdentificationPhoneNumbers(to context: CXCallDirectoryExtensionContext) {
+        // Retrieve any changes to the set of phone numbers to identify from data store.
+    }
+
+}
+
+extension CallDirectoryHandler: CXCallDirectoryExtensionContextDelegate {
+
+    func requestFailed(for extensionContext: CXCallDirectoryExtensionContext, withError error: Error) {
+        // An error occurred while adding blocking or identification entries, check the NSError for details.
+        // For Call Directory error codes, see the CXErrorCodeCallDirectoryManagerError enum in <CallKit/CXError.h>.
+    }
+
+}

--- a/packages/create-target/templates/file-provider/FileProviderEnumerator.swift
+++ b/packages/create-target/templates/file-provider/FileProviderEnumerator.swift
@@ -1,0 +1,27 @@
+import FileProvider
+
+class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
+
+    private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
+
+    init(enumeratedItemIdentifier: NSFileProviderItemIdentifier) {
+        self.enumeratedItemIdentifier = enumeratedItemIdentifier
+        super.init()
+    }
+
+    func invalidate() {
+        // Clean up any resources
+    }
+
+    func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
+        observer.finishEnumerating(upTo: nil)
+    }
+
+    func enumerateChanges(for observer: NSFileProviderChangeObserver, from anchor: NSFileProviderSyncAnchor) {
+        observer.finishEnumeratingChanges(upTo: anchor, moreComing: false)
+    }
+
+    func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
+        completionHandler(NSFileProviderSyncAnchor("anchor".data(using: .utf8)!))
+    }
+}

--- a/packages/create-target/templates/file-provider/FileProviderExtension.swift
+++ b/packages/create-target/templates/file-provider/FileProviderExtension.swift
@@ -1,0 +1,42 @@
+import FileProvider
+import UniformTypeIdentifiers
+
+class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
+
+    required init(domain: NSFileProviderDomain) {
+        super.init()
+    }
+
+    func invalidate() {
+        // Clean up any resources
+    }
+
+    func item(for identifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
+        completionHandler(FileProviderItem(identifier: identifier), nil)
+        return Progress()
+    }
+
+    func fetchContents(for itemIdentifier: NSFileProviderItemIdentifier, version requestedVersion: NSFileProviderItemVersion?, request: NSFileProviderRequest, completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
+        completionHandler(nil, nil, NSError(domain: NSCocoaErrorDomain, code: NSFeatureUnsupportedError))
+        return Progress()
+    }
+
+    func createItem(basedOn itemTemplate: NSFileProviderItem, fields: NSFileProviderItemFields, contents url: URL?, options: NSFileProviderCreateItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+        completionHandler(itemTemplate, [], false, nil)
+        return Progress()
+    }
+
+    func modifyItem(_ item: NSFileProviderItem, baseVersion version: NSFileProviderItemVersion, changedFields: NSFileProviderItemFields, contents newContents: URL?, options: NSFileProviderModifyItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+        completionHandler(item, [], false, nil)
+        return Progress()
+    }
+
+    func deleteItem(identifier: NSFileProviderItemIdentifier, baseVersion version: NSFileProviderItemVersion, options: NSFileProviderDeleteItemOptions = [], request: NSFileProviderRequest, completionHandler: @escaping (Error?) -> Void) -> Progress {
+        completionHandler(nil)
+        return Progress()
+    }
+
+    func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
+        return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier)
+    }
+}

--- a/packages/create-target/templates/file-provider/FileProviderItem.swift
+++ b/packages/create-target/templates/file-provider/FileProviderItem.swift
@@ -1,0 +1,31 @@
+import FileProvider
+import UniformTypeIdentifiers
+
+class FileProviderItem: NSObject, NSFileProviderItem {
+
+    let itemIdentifier: NSFileProviderItemIdentifier
+
+    init(identifier: NSFileProviderItemIdentifier) {
+        self.itemIdentifier = identifier
+    }
+
+    var identifier: NSFileProviderItemIdentifier {
+        return itemIdentifier
+    }
+
+    var parentItemIdentifier: NSFileProviderItemIdentifier {
+        return .rootContainer
+    }
+
+    var capabilities: NSFileProviderItemCapabilities {
+        return [.allowsReading, .allowsWriting, .allowsRenaming, .allowsReparenting, .allowsTrashing, .allowsDeleting]
+    }
+
+    var filename: String {
+        return "Example File"
+    }
+
+    var contentType: UTType {
+        return .plainText
+    }
+}

--- a/packages/create-target/templates/message-filter/MessageFilterExtension.swift
+++ b/packages/create-target/templates/message-filter/MessageFilterExtension.swift
@@ -1,0 +1,35 @@
+import IdentityLookup
+
+final class MessageFilterExtension: ILMessageFilterExtension {}
+
+extension MessageFilterExtension: ILMessageFilterQueryHandling {
+
+    func handle(_ queryRequest: ILMessageFilterQueryRequest, context: ILMessageFilterExtensionContext, completion: @escaping (ILMessageFilterQueryResponse) -> Void) {
+        // First, check whether to filter using offline data (if possible).
+        let offlineAction = self.offlineAction(for: queryRequest)
+
+        switch offlineAction {
+        case .allow, .junk, .promotion, .transaction:
+            // Based on offline data, we know this message should either be allowed or filtered, so report
+            let response = ILMessageFilterQueryResponse()
+            response.action = offlineAction
+            completion(response)
+
+        case .none:
+            // Based on offline data, we don't know whether this message should be allowed or filtered.
+            // Defer to network.
+            let response = ILMessageFilterQueryResponse()
+            response.action = .none
+            completion(response)
+
+        @unknown default:
+            break
+        }
+    }
+
+    private func offlineAction(for queryRequest: ILMessageFilterQueryRequest) -> ILMessageFilterAction {
+        // Replace with logic to perform offline check whether to filter first (if possible).
+        return .none
+    }
+
+}


### PR DESCRIPTION
## Summary

- Add **file-provider** (`com.apple.fileprovider-nonui`) — File Provider extension with `UniformTypeIdentifiers` framework and app groups support
- Add **broadcast-upload** (`com.apple.broadcast-services-upload`) — Broadcast Upload extension with `ReplayKit` framework
- Add **call-directory** (`com.apple.callkit.call-directory`) — Call Directory extension with `CallKit` framework
- Add **message-filter** (`com.apple.identitylookup.message-filter`) — Message Filter extension with `IdentityLookup` framework

Each type includes: registry entry, Info.plist generation, configuration list build settings, Swift templates, e2e fixture config, and updated README.

## Test plan

- [x] `bunx tsc --noEmit` passes in `packages/apple-targets`
- [x] `bun test` passes in `packages/apple-targets` (4/4 unit tests)
- [x] `bunx expo-module build` succeeds in `packages/apple-targets`
- [x] `bun run test` passes in `packages/create-target` (22/22 tests, 4 new snapshots)
- [ ] e2e xcodebuild tests (requires macOS + Xcode in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)