### PR TITLE
feat(targets): add quicklook-preview, spotlight-delegate, virtual-conference, shield-action, shield-config

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -318,6 +318,11 @@ Ideally, this would be generated automatically based on a fully qualified Xcode 
 | classkit-context        | ClassKit Context Provider Extension|
 | unwanted-communication  | Unwanted Communication Reporting   |
 | photo-editing           | Photo Editing Extension            |
+| quicklook-preview       | Quick Look Preview Extension       |
+| spotlight-delegate      | CoreSpotlight Delegate Extension   |
+| virtual-conference      | Virtual Conference Provider        |
+| shield-action           | Shield Action Extension            |
+| shield-config           | Shield Configuration Extension     |
 
 
 <!-- | imessage             | iMessage Extension               | -->
@@ -329,13 +334,8 @@ The following iOS extension types exist in Xcode but aren't supported yet. Contr
 | Extension Point Identifier | Xcode Template Name |
 | --- | --- |
 | `com.apple.printing.discovery` | Print Service Extension |
-| `com.apple.quicklook.preview` | Quick Look Preview Extension |
-| `com.apple.spotlight.index` | CoreSpotlight Delegate Extension |
 | `com.apple.ctk-tokens` | Smart Card / Persistent Token Extension |
-| `com.apple.calendar.virtualconference` | Virtual Conference Provider Extension |
 | `com.apple.AppSSO.idp-extension` | Authentication Services Extension |
-| `com.apple.ManagedSettings.shield-action-service` | Shield Action Extension |
-| `com.apple.ManagedSettingsUI.shield-configuration-service` | Shield Configuration Extension |
 | `com.apple.tv-top-shelf` | TV Top Shelf Extension (tvOS) |
 | `com.apple.FinderSync` | Finder Sync Extension (macOS) |
 | `com.apple.email.extension` | Mail Extension (macOS) |

--- a/packages/apple-targets/e2e/__tests__/build.test.ts
+++ b/packages/apple-targets/e2e/__tests__/build.test.ts
@@ -126,6 +126,23 @@ const TARGET_REGISTRY: TargetEntry[] = [
     target: "unwantedcommunication",
   },
   { type: "photo-editing", dir: "photo-editing", target: "photoediting" },
+  {
+    type: "quicklook-preview",
+    dir: "quicklook-preview",
+    target: "quicklookpreview",
+  },
+  {
+    type: "spotlight-delegate",
+    dir: "spotlight-delegate",
+    target: "spotlightdelegate",
+  },
+  {
+    type: "virtual-conference",
+    dir: "virtual-conference",
+    target: "virtualconference",
+  },
+  { type: "shield-action", dir: "shield-action", target: "shieldaction" },
+  { type: "shield-config", dir: "shield-config", target: "shieldconfig" },
 ];
 
 // Derived from the central TARGET_REGISTRY — no need to maintain by hand.

--- a/packages/apple-targets/e2e/fixture/targets/quicklook-preview/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/quicklook-preview/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "quicklook-preview" }

--- a/packages/apple-targets/e2e/fixture/targets/shield-action/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/shield-action/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "shield-action" }

--- a/packages/apple-targets/e2e/fixture/targets/shield-config/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/shield-config/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "shield-config" }

--- a/packages/apple-targets/e2e/fixture/targets/spotlight-delegate/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/spotlight-delegate/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "spotlight-delegate" }

--- a/packages/apple-targets/e2e/fixture/targets/virtual-conference/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/virtual-conference/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "virtual-conference" }

--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -813,6 +813,11 @@ function getConfigurationListBuildSettingsForType(
     case "classkit-context":
     case "unwanted-communication":
     case "photo-editing":
+    case "quicklook-preview":
+    case "spotlight-delegate":
+    case "virtual-conference":
+    case "shield-action":
+    case "shield-config":
       return createNotificationContentConfigurationList(props);
     default:
       const exhaustiveCheck: never = props.type;

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -216,6 +216,32 @@ export const TARGET_REGISTRY = {
     frameworks: ["Photos", "PhotosUI"],
     displayName: "Photo Editing",
   },
+  "quicklook-preview": {
+    extensionPointIdentifier: "com.apple.quicklook.preview",
+    needsEmbeddedSwift: true,
+    frameworks: ["QuickLook"],
+    displayName: "Quick Look Preview",
+  },
+  "spotlight-delegate": {
+    extensionPointIdentifier: "com.apple.spotlight.index",
+    frameworks: ["CoreSpotlight"],
+    displayName: "CoreSpotlight Delegate",
+  },
+  "virtual-conference": {
+    extensionPointIdentifier: "com.apple.calendar.virtualconference",
+    displayName: "Virtual Conference Provider",
+  },
+  "shield-action": {
+    extensionPointIdentifier: "com.apple.ManagedSettings.shield-action-service",
+    frameworks: ["ManagedSettings"],
+    displayName: "Shield Action",
+  },
+  "shield-config": {
+    extensionPointIdentifier:
+      "com.apple.ManagedSettingsUI.shield-configuration-service",
+    frameworks: ["ManagedSettings", "ManagedSettingsUI"],
+    displayName: "Shield Configuration",
+  },
 } as const satisfies Record<string, TargetDefinition>;
 
 export type ExtensionType = keyof typeof TARGET_REGISTRY;
@@ -594,6 +620,49 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
           NSExtensionAttributes: {
             PHSupportedMediaTypes: ["Image"],
           },
+        },
+      };
+    case "quicklook-preview":
+      return {
+        NSExtension: {
+          NSExtensionAttributes: {
+            QLSupportedContentTypes: [],
+          },
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).PreviewViewController",
+          NSExtensionPointIdentifier,
+        },
+      };
+    case "spotlight-delegate":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).IndexRequestHandler",
+        },
+      };
+    case "virtual-conference":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).VirtualConferenceProvider",
+        },
+      };
+    case "shield-action":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).ShieldActionExtension",
+        },
+      };
+    case "shield-config":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).ShieldConfigurationExtension",
         },
       };
     default:

--- a/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
+++ b/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
@@ -163,6 +163,14 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for quicklook-preview 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"quicklook-preview\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for quicklook-thumbnail 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
@@ -190,6 +198,22 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for shield-action 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"shield-action\\",
+  entitlements: {\\"com.apple.developer.family-controls\\":true},
+});"
+`;
+
+exports[`getTemplateConfig should return a valid template for shield-config 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"shield-config\\",
+  entitlements: {\\"com.apple.developer.family-controls\\":true},
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for spotlight 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
@@ -198,10 +222,26 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for spotlight-delegate 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"spotlight-delegate\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for unwanted-communication 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
   type: \\"unwanted-communication\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
+exports[`getTemplateConfig should return a valid template for virtual-conference 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"virtual-conference\\",
   entitlements: { /* Add entitlements */ },
 });"
 `;

--- a/packages/create-target/src/__tests__/createAsync.test.ts
+++ b/packages/create-target/src/__tests__/createAsync.test.ts
@@ -28,6 +28,11 @@ const ALL_TARGET_TYPES = [
   "classkit-context",
   "unwanted-communication",
   "photo-editing",
+  "quicklook-preview",
+  "spotlight-delegate",
+  "virtual-conference",
+  "shield-action",
+  "shield-config",
 ];
 
 describe(getTemplateConfig, () => {

--- a/packages/create-target/templates/quicklook-preview/PreviewViewController.swift
+++ b/packages/create-target/templates/quicklook-preview/PreviewViewController.swift
@@ -1,0 +1,19 @@
+import UIKit
+import QuickLook
+
+class PreviewViewController: UIViewController, QLPreviewingController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    func preparePreviewOfFile(at url: URL, completionHandler handler: @escaping (Error?) -> Void) {
+        // Add the supported content types to the QLSupportedContentTypes array in the Info.plist.
+        handler(nil)
+    }
+
+    func preparePreviewOfSearchableItem(identifier: String, queryString: String?, completionHandler handler: @escaping (Error?) -> Void) {
+        // Perform any setup necessary in order to prepare the view.
+        handler(nil)
+    }
+}

--- a/packages/create-target/templates/shield-action/ShieldActionExtension.swift
+++ b/packages/create-target/templates/shield-action/ShieldActionExtension.swift
@@ -1,0 +1,37 @@
+import ManagedSettings
+
+class ShieldActionExtension: ShieldActionDelegate {
+
+    override func handle(action: ShieldAction, for application: ApplicationToken, completionHandler: @escaping (ShieldActionResponse) -> Void) {
+        switch action {
+        case .primaryButtonPressed:
+            completionHandler(.close)
+        case .secondaryButtonPressed:
+            completionHandler(.defer)
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    override func handle(action: ShieldAction, for webDomain: WebDomainToken, completionHandler: @escaping (ShieldActionResponse) -> Void) {
+        switch action {
+        case .primaryButtonPressed:
+            completionHandler(.close)
+        case .secondaryButtonPressed:
+            completionHandler(.defer)
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    override func handle(action: ShieldAction, for category: ActivityCategoryToken, completionHandler: @escaping (ShieldActionResponse) -> Void) {
+        switch action {
+        case .primaryButtonPressed:
+            completionHandler(.close)
+        case .secondaryButtonPressed:
+            completionHandler(.defer)
+        @unknown default:
+            fatalError()
+        }
+    }
+}

--- a/packages/create-target/templates/shield-config/ShieldConfigurationExtension.swift
+++ b/packages/create-target/templates/shield-config/ShieldConfigurationExtension.swift
@@ -1,0 +1,22 @@
+import ManagedSettings
+import ManagedSettingsUI
+import UIKit
+
+class ShieldConfigurationExtension: ShieldConfigurationDataSource {
+
+    override func configuration(shielding application: Application) -> ShieldConfiguration {
+        return ShieldConfiguration()
+    }
+
+    override func configuration(shielding application: Application, in category: ActivityCategory) -> ShieldConfiguration {
+        return ShieldConfiguration()
+    }
+
+    override func configuration(shielding webDomain: WebDomain) -> ShieldConfiguration {
+        return ShieldConfiguration()
+    }
+
+    override func configuration(shielding webDomain: WebDomain, in category: ActivityCategory) -> ShieldConfiguration {
+        return ShieldConfiguration()
+    }
+}

--- a/packages/create-target/templates/spotlight-delegate/IndexRequestHandler.swift
+++ b/packages/create-target/templates/spotlight-delegate/IndexRequestHandler.swift
@@ -1,0 +1,14 @@
+import CoreSpotlight
+
+class IndexRequestHandler: CSIndexExtensionRequestHandler {
+
+    override func searchableIndex(_ searchableIndex: CSSearchableIndex, reindexAllSearchableItemsWithAcknowledgementHandler acknowledgementHandler: @escaping () -> Void) {
+        // Reindex all data with the provided index
+        acknowledgementHandler()
+    }
+
+    override func searchableIndex(_ searchableIndex: CSSearchableIndex, reindexSearchableItemsWithIdentifiers identifiers: [String], acknowledgementHandler: @escaping () -> Void) {
+        // Reindex any items with the given identifiers and the provided index
+        acknowledgementHandler()
+    }
+}

--- a/packages/create-target/templates/virtual-conference/VirtualConferenceProvider.swift
+++ b/packages/create-target/templates/virtual-conference/VirtualConferenceProvider.swift
@@ -1,0 +1,18 @@
+import EventKit
+
+class VirtualConferenceProvider: EKVirtualConferenceProvider {
+
+    override func fetchVirtualConference(identifier: String, completionHandler: @escaping (EKVirtualConferenceDescriptor?, Error?) -> Void) {
+        // Create and return a virtual conference descriptor
+        let urlDescriptor = EKVirtualConferenceURLDescriptor(
+            title: "Join Meeting",
+            url: URL(string: "https://example.com/meeting")!
+        )
+        let descriptor = EKVirtualConferenceDescriptor(
+            title: "Example Meeting",
+            urlDescriptors: [urlDescriptor],
+            conferenceDetails: nil
+        )
+        completionHandler(descriptor, nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Add **quicklook-preview** (`com.apple.quicklook.preview`) — Quick Look Preview extension with `QuickLook` framework
- Add **spotlight-delegate** (`com.apple.spotlight.index`) — CoreSpotlight Delegate extension with `CoreSpotlight` framework
- Add **virtual-conference** (`com.apple.calendar.virtualconference`) — Virtual Conference Provider extension with `EventKit`
- Add **shield-action** (`com.apple.ManagedSettings.shield-action-service`) — Shield Action extension with `ManagedSettings` framework
- Add **shield-config** (`com.apple.ManagedSettingsUI.shield-configuration-service`) — Shield Configuration extension with `ManagedSettings` + `ManagedSettingsUI` frameworks

Note: `shield-action` and `shield-config` already have recommended entitlements (`com.apple.developer.family-controls`) configured in `create-target`.

## Test plan

- [x] `bunx tsc --noEmit` passes in `packages/apple-targets`
- [x] `bun test` passes in `packages/apple-targets` (4/4 unit tests)
- [x] `bunx expo-module build` succeeds in `packages/apple-targets`
- [x] `bun run test` passes in `packages/create-target` (32/32 tests, 5 new snapshots)
- [ ] e2e xcodebuild tests (requires macOS + Xcode in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)