### PR TITLE
feat(targets): add print-service, smart-card, authentication-services

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -323,19 +323,19 @@ Ideally, this would be generated automatically based on a fully qualified Xcode 
 | virtual-conference      | Virtual Conference Provider        |
 | shield-action           | Shield Action Extension            |
 | shield-config           | Shield Configuration Extension     |
+| print-service           | Print Service Extension            |
+| smart-card              | Smart Card / Persistent Token      |
+| authentication-services | Authentication Services Extension  |
 
 
 <!-- | imessage             | iMessage Extension               | -->
 
 ### Not yet supported
 
-The following iOS extension types exist in Xcode but aren't supported yet. Contributions welcome! See `docs/xcode-target-discovery.md` for details on how these were discovered.
+The following extension types exist in Xcode but aren't supported yet. Contributions welcome! See `docs/xcode-target-discovery.md` for details on how these were discovered.
 
 | Extension Point Identifier | Xcode Template Name |
 | --- | --- |
-| `com.apple.printing.discovery` | Print Service Extension |
-| `com.apple.ctk-tokens` | Smart Card / Persistent Token Extension |
-| `com.apple.AppSSO.idp-extension` | Authentication Services Extension |
 | `com.apple.tv-top-shelf` | TV Top Shelf Extension (tvOS) |
 | `com.apple.FinderSync` | Finder Sync Extension (macOS) |
 | `com.apple.email.extension` | Mail Extension (macOS) |

--- a/packages/apple-targets/e2e/__tests__/build.test.ts
+++ b/packages/apple-targets/e2e/__tests__/build.test.ts
@@ -143,6 +143,13 @@ const TARGET_REGISTRY: TargetEntry[] = [
   },
   { type: "shield-action", dir: "shield-action", target: "shieldaction" },
   { type: "shield-config", dir: "shield-config", target: "shieldconfig" },
+  { type: "print-service", dir: "print-service", target: "printservice" },
+  { type: "smart-card", dir: "smart-card", target: "smartcard" },
+  {
+    type: "authentication-services",
+    dir: "authentication-services",
+    target: "authenticationservices",
+  },
 ];
 
 // Derived from the central TARGET_REGISTRY — no need to maintain by hand.

--- a/packages/apple-targets/e2e/fixture/targets/authentication-services/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/authentication-services/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "authentication-services" }

--- a/packages/apple-targets/e2e/fixture/targets/print-service/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/print-service/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "print-service" }

--- a/packages/apple-targets/e2e/fixture/targets/smart-card/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/smart-card/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "smart-card" }

--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -46,7 +46,7 @@ export type XcodeSettings = {
 
 export type DeviceFamily = "phone" | "tablet";
 
-function createNotificationContentConfigurationList({
+function createDefaultConfigurationList({
   name,
   displayName,
   cwd,
@@ -818,7 +818,10 @@ function getConfigurationListBuildSettingsForType(
     case "virtual-conference":
     case "shield-action":
     case "shield-config":
-      return createNotificationContentConfigurationList(props);
+    case "print-service":
+    case "smart-card":
+    case "authentication-services":
+      return createDefaultConfigurationList(props);
     default:
       const exhaustiveCheck: never = props.type;
       throw new Error(`Unhandled case: ${exhaustiveCheck}`);

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -242,6 +242,22 @@ export const TARGET_REGISTRY = {
     frameworks: ["ManagedSettings", "ManagedSettingsUI"],
     displayName: "Shield Configuration",
   },
+  "print-service": {
+    extensionPointIdentifier: "com.apple.printing.discovery",
+    displayName: "Print Service",
+  },
+  "smart-card": {
+    extensionPointIdentifier: "com.apple.ctk-tokens",
+    frameworks: ["CryptoTokenKit"],
+    displayName: "Smart Card",
+    description: "Persistent token / smart card extension",
+  },
+  "authentication-services": {
+    extensionPointIdentifier: "com.apple.AppSSO.idp-extension",
+    frameworks: ["AuthenticationServices"],
+    displayName: "Authentication Services",
+    description: "Single sign-on extension",
+  },
 } as const satisfies Record<string, TargetDefinition>;
 
 export type ExtensionType = keyof typeof TARGET_REGISTRY;
@@ -663,6 +679,30 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
           NSExtensionPointIdentifier,
           NSExtensionPrincipalClass:
             "$(PRODUCT_MODULE_NAME).ShieldConfigurationExtension",
+        },
+      };
+    case "print-service":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).PrintServiceExtension",
+        },
+      };
+    case "smart-card":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).TokenExtension",
+        },
+      };
+    case "authentication-services":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).AuthenticationExtension",
         },
       };
     default:

--- a/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
+++ b/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
@@ -26,6 +26,14 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for authentication-services 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"authentication-services\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for bg-download 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
@@ -163,6 +171,14 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for print-service 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"print-service\\",
+  entitlements: { /* Add entitlements */ },
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for quicklook-preview 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({
@@ -211,6 +227,14 @@ exports[`getTemplateConfig should return a valid template for shield-config 1`] 
 module.exports = config => ({
   type: \\"shield-config\\",
   entitlements: {\\"com.apple.developer.family-controls\\":true},
+});"
+`;
+
+exports[`getTemplateConfig should return a valid template for smart-card 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"smart-card\\",
+  entitlements: { /* Add entitlements */ },
 });"
 `;
 

--- a/packages/create-target/src/__tests__/createAsync.test.ts
+++ b/packages/create-target/src/__tests__/createAsync.test.ts
@@ -33,6 +33,9 @@ const ALL_TARGET_TYPES = [
   "virtual-conference",
   "shield-action",
   "shield-config",
+  "print-service",
+  "smart-card",
+  "authentication-services",
 ];
 
 describe(getTemplateConfig, () => {

--- a/packages/create-target/templates/authentication-services/AuthenticationExtension.swift
+++ b/packages/create-target/templates/authentication-services/AuthenticationExtension.swift
@@ -1,0 +1,8 @@
+import AuthenticationServices
+
+class AuthenticationExtension: NSObject, ASAuthorizationProviderExtensionAuthorizationRequestHandler {
+
+    func beginAuthorization(with request: ASAuthorizationProviderExtensionAuthorizationRequest) {
+        request.doNotHandle()
+    }
+}

--- a/packages/create-target/templates/print-service/PrintServiceExtension.swift
+++ b/packages/create-target/templates/print-service/PrintServiceExtension.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class PrintServiceExtension: NSObject {
+
+}

--- a/packages/create-target/templates/smart-card/TokenExtension.swift
+++ b/packages/create-target/templates/smart-card/TokenExtension.swift
@@ -1,0 +1,5 @@
+import CryptoTokenKit
+
+class TokenExtension: TKSmartCardTokenDriver {
+
+}


### PR DESCRIPTION
## Summary

- Add **print-service** (`com.apple.printing.discovery`) — Print Service extension
- Add **smart-card** (`com.apple.ctk-tokens`) — Smart Card / Persistent Token extension with `CryptoTokenKit` framework
- Add **authentication-services** (`com.apple.AppSSO.idp-extension`) — Authentication Services SSO extension with `AuthenticationServices` framework
- Rename `createNotificationContentConfigurationList` → `createDefaultConfigurationList` since it serves as the default for most extension types

This clears all iOS extension types from the unsupported list. Only tvOS/macOS-only types remain (`tv-top-shelf`, `FinderSync`, `email`).

## Test plan

- [x] `bunx tsc --noEmit` passes in `packages/apple-targets`
- [x] `bun test` passes in `packages/apple-targets` (4/4 unit tests)
- [x] `bunx expo-module build` succeeds in `packages/apple-targets`
- [x] `bun run test` passes in `packages/create-target` (35/35 tests, 3 new snapshots)
- [ ] e2e xcodebuild tests (requires macOS + Xcode in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)