### PR TITLE
feat(targets): support discovering targets from libraries

### DIFF
--- a/packages/apple-targets/src/config-plugin.ts
+++ b/packages/apple-targets/src/config-plugin.ts
@@ -1,6 +1,7 @@
 import { ConfigPlugin } from "expo/config-plugins";
 import { globSync } from "glob";
 import path from "path";
+import fs from "fs";
 import chalk from "chalk";
 
 import type { Config, ConfigFunction } from "./config";
@@ -14,10 +15,19 @@ export const withTargetsDir: ConfigPlugin<
     appleTeamId?: string;
     match?: string;
     root?: string;
+    /**
+     * Array of npm package names or paths that ship apple targets.
+     * The plugin will search for `targets/* /expo-target.config.@(json|js)` in each location.
+     * - Package names (e.g. "expo-screen-time") are resolved via require.resolve
+     * - Paths starting with "." or "/" are resolved relative to project root
+     * @example ["expo-screen-time"] - npm package
+     * @example ["./node_modules/expo-screen-time", "../my-library"] - paths
+     */
+    libraryTargets?: string[];
   } | void
 > = (config, _props) => {
   let { appleTeamId = config?.ios?.appleTeamId } = _props || {};
-  const { root = "./targets", match = "*" } = _props || {};
+  const { root = "./targets", match = "*", libraryTargets = [] } = _props || {};
   const projectRoot = config._internal!.projectRoot;
 
   if (!config.ios?.bundleIdentifier) {
@@ -35,11 +45,55 @@ export const withTargetsDir: ConfigPlugin<
     );
   }
 
+  // Find targets in the user's project
   const targets = globSync(`${root}/${match}/expo-target.config.@(json|js)`, {
-    // const targets = globSync(`./targets/action/expo-target.config.@(json|js)`, {
     cwd: projectRoot,
     absolute: true,
   });
+
+  // Find targets shipped by npm packages (libraries)
+  const libraryTargetPaths = libraryTargets.flatMap((pkgNameOrPath) => {
+    let pkgDir: string;
+
+    // Check if it's a path (starts with . or /)
+    if (pkgNameOrPath.startsWith(".") || pkgNameOrPath.startsWith("/")) {
+      pkgDir = path.resolve(projectRoot, pkgNameOrPath);
+      if (!fs.existsSync(pkgDir)) {
+        warnOnce(
+          chalk`{yellow [bacons/apple-targets]} Library path does not exist: {cyan ${pkgDir}}`
+        );
+        return [];
+      }
+    } else {
+      // It's a package name - resolve via require.resolve
+      try {
+        const pkgJsonPath = require.resolve(`${pkgNameOrPath}/package.json`, {
+          paths: [projectRoot],
+        });
+        pkgDir = path.dirname(pkgJsonPath);
+      } catch (error) {
+        warnOnce(
+          chalk`{yellow [bacons/apple-targets]} Could not find library targets for package {cyan ${pkgNameOrPath}}: ${error}`
+        );
+        return [];
+      }
+    }
+
+    const targets = globSync(`targets/*/expo-target.config.@(json|js)`, {
+      cwd: pkgDir,
+      absolute: true,
+    });
+
+    if (targets.length === 0) {
+      warnOnce(
+        chalk`{yellow [bacons/apple-targets]} No targets found in {cyan ${pkgDir}/targets/}`
+      );
+    }
+
+    return targets;
+  });
+
+  targets.push(...libraryTargetPaths);
 
   targets.forEach((configPath) => {
     const targetConfig = require(configPath);
@@ -47,6 +101,11 @@ export const withTargetsDir: ConfigPlugin<
     // If it's a function, evaluate it
     if (typeof targetConfig === "function") {
       evaluatedTargetConfigObject = targetConfig(config);
+
+      // Allow config functions to return null/undefined to skip the target
+      if (evaluatedTargetConfigObject === null || evaluatedTargetConfigObject === undefined) {
+        return; // Skip this target
+      }
 
       if (typeof evaluatedTargetConfigObject !== "object") {
         throw new Error(

--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -858,6 +858,7 @@ function getConfigurationListBuildSettingsForType(
     case "bg-download":
     case "credentials-provider":
     case "device-activity-monitor":
+    case "device-activity-report":
     case "intent":
     case "intent-ui":
     case "location-push":

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -141,6 +141,7 @@ export const TARGET_REGISTRY = {
   "device-activity-monitor": {
     extensionPointIdentifier: "com.apple.deviceactivity.monitor-extension",
     frameworks: ["DeviceActivity"],
+    appGroupsByDefault: true,
     displayName: "Device Activity Monitor",
   },
   "device-activity-report": {
@@ -249,12 +250,14 @@ export const TARGET_REGISTRY = {
   "shield-action": {
     extensionPointIdentifier: "com.apple.ManagedSettings.shield-action-service",
     frameworks: ["ManagedSettings"],
+    appGroupsByDefault: true,
     displayName: "Shield Action",
   },
   "shield-config": {
     extensionPointIdentifier:
       "com.apple.ManagedSettingsUI.shield-configuration-service",
     frameworks: ["ManagedSettings", "ManagedSettingsUI"],
+    appGroupsByDefault: true,
     displayName: "Shield Configuration",
   },
   "print-service": {

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -143,6 +143,12 @@ export const TARGET_REGISTRY = {
     frameworks: ["DeviceActivity"],
     displayName: "Device Activity Monitor",
   },
+  "device-activity-report": {
+    extensionPointIdentifier: "com.apple.deviceactivity.report-extension",
+    frameworks: ["DeviceActivity", "SwiftUI"],
+    appGroupsByDefault: true,
+    displayName: "Device Activity Report",
+  },
   "network-packet-tunnel": {
     extensionPointIdentifier: "com.apple.networkextension.packet-tunnel",
     needsEmbeddedSwift: true,
@@ -702,6 +708,12 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
           NSExtensionPointIdentifier,
           NSExtensionPrincipalClass:
             "$(PRODUCT_MODULE_NAME).DeviceActivityMonitorExtension",
+        },
+      };
+    case "device-activity-report":
+      return {
+        EXAppExtensionAttributes: {
+          EXExtensionPointIdentifier: NSExtensionPointIdentifier,
         },
       };
     case "print-service":


### PR DESCRIPTION
# Motivation

I'm building `expo-screen-time` (Not public yet, I'm working on it 😅), an Expo module that wraps Apple's Screen Time API.
This one needs four extensions to work: `device-activity-monitor`, `device-activity-report`, `shield-config`, and `shield-action`.

I understand `@bacons/apple-targets` was originally designed for app developers to add targets directly inside their own apps, not for libraries to ship targets that consumer apps pick up automatically. That works great for app-side use cases, but it creates friction for libraries that need to bundle extensions: every consumer app would have to manually copy the target folders into their own `targets/` directory and keep them in sync with the library's updates. For a library like `expo-screen-time` with four extensions, that's a lot of manual setup and a maintenance burden I'd rather not push onto users.

This PR proposes adding library support on top of the existing design, without changing how app-side targets work today, so I can ship `expo-screen-time` with its targets bundled inside the npm package and let consumers just install and configure it.

While integrating, I also noticed that `device-activity-report` is missing from the supported target types, so I've added it.

# Execution

## `libraryTargets` option

Adds a new optional `libraryTargets` option to the plugin config. When set, the plugin discovers targets from npm libraries at prebuild time, in addition to the consumer app's own `targets/` directory.
App-side targets continue to work exactly as before, this is purely additive.

```json
{
  "plugins": [
    ["@bacons/apple-targets", {
      "libraryTargets": ["expo-screen-time"]
    }]
  ]
}
```

The plugin:
1. Resolves each entry, package names via require.resolve, paths starting with . or / relative to project root
2. Searches for targets/*/expo-target.config.@(json|js) in each location
3. Merges them with the consumer app's own targets

Library targets can use a function-based config to conditionally enable themselves based on the library's own plugin config:

```typescript
// node_modules/expo-screen-time/targets/ShieldConfigurationExtension/expo-target.config.js
module.exports = (config) => {
  if (!shouldIncludeTarget(config, 'ShieldConfigurationExtension')) return null;
  return {
    type: 'shield-config',
    name: 'ShieldConfigurationExtension',
    deploymentTarget: '16.0',
    entitlements: { 'com.apple.developer.family-controls': true },
  };
};
```

Returning null skips the target entirely, giving consumers fine-grained control over which extensions to include.

## New target type: device-activity-report

Adds the missing counterpart to device-activity-monitor. Required for any app that wants to display custom Screen Time analytics views via DeviceActivityReportScene.

- Extension point: com.apple.deviceactivity.report-extension
- Frameworks: DeviceActivity, SwiftUI
- App groups synced from main target by default
- Custom Info.plist using EXAppExtensionAttributes (required by Apple's report extension architecture)

# Test Plan

Verified end-to-end with expo-screen-time on a physical iPhone (iOS 26.4):

- libraryTargets: ["expo-screen-time"] in app.json correctly discovers all four extensions from node_modules/expo-screen-time/targets/
- A library target returning null from its config function is skipped (verified by toggling extensions on/off)
- Local targets in the consumer's targets/ directory still work alongside library targets
- device-activity-report target builds and the embedded DeviceActivityReport SwiftUI view renders custom analytics
- Existing target types still build (no regressions)