### PR TITLE
feat(targets): add Apple Wallet In-App Provisioning extensions (`wall…

### DIFF
--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -362,6 +362,8 @@ Ideally, this would be generated automatically based on a fully qualified Xcode 
 | print-service             | Print Service Extension            |
 | smart-card                | Smart Card / Persistent Token      |
 | authentication-services   | Authentication Services Extension  |
+| wallet                    | Wallet Provisioning (Non-UI)       |
+| wallet-ui                 | Wallet Provisioning UI             |
 
 
 <!-- | imessage             | iMessage Extension               | -->

--- a/packages/apple-targets/e2e/__tests__/build.test.ts
+++ b/packages/apple-targets/e2e/__tests__/build.test.ts
@@ -153,6 +153,8 @@ const TARGET_REGISTRY: TargetEntry[] = [
     dir: "authentication-services",
     target: "authenticationservices",
   },
+  { type: "wallet", dir: "wallet", target: "wallet" },
+  { type: "wallet-ui", dir: "wallet-ui", target: "walletui" },
 ];
 
 // Derived from the central TARGET_REGISTRY — no need to maintain by hand.

--- a/packages/apple-targets/e2e/fixture/targets/wallet-ui/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/wallet-ui/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "wallet-ui" }

--- a/packages/apple-targets/e2e/fixture/targets/wallet/expo-target.config.json
+++ b/packages/apple-targets/e2e/fixture/targets/wallet/expo-target.config.json
@@ -1,0 +1,1 @@
+{ "type": "wallet" }

--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -886,6 +886,8 @@ function getConfigurationListBuildSettingsForType(
     case "print-service":
     case "smart-card":
     case "authentication-services":
+    case "wallet":
+    case "wallet-ui":
       return createDefaultConfigurationList(props);
     default:
       const exhaustiveCheck: never = props.type;

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -267,6 +267,23 @@ export const TARGET_REGISTRY = {
     displayName: "Authentication Services",
     description: "Single sign-on extension",
   },
+  wallet: {
+    extensionPointIdentifier: "com.apple.PassKit.issuer-provisioning",
+    frameworks: ["PassKit"],
+    appGroupsByDefault: true,
+    displayName: "Apple Wallet (Non-UI)",
+    description:
+      "In-App Provisioning Extension (Non-UI) for adding payment passes to Apple Wallet",
+  },
+  "wallet-ui": {
+    extensionPointIdentifier:
+      "com.apple.PassKit.issuer-provisioning.authorization",
+    frameworks: ["PassKit", "UIKit"],
+    appGroupsByDefault: true,
+    displayName: "Apple Wallet (UI)",
+    description:
+      "In-App Provisioning Authorization UI Extension for Apple Wallet",
+  },
 } as const satisfies Record<string, TargetDefinition>;
 
 export type ExtensionType = keyof typeof TARGET_REGISTRY;
@@ -726,6 +743,22 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
           NSExtensionPointIdentifier,
           NSExtensionPrincipalClass:
             "$(PRODUCT_MODULE_NAME).AuthenticationExtension",
+        },
+      };
+    case "wallet":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).IssuerProvisioningHandler",
+        },
+      };
+    case "wallet-ui":
+      return {
+        NSExtension: {
+          NSExtensionPointIdentifier,
+          NSExtensionPrincipalClass:
+            "$(PRODUCT_MODULE_NAME).IssuerProvisioningAuthorizationViewController",
         },
       };
     default:

--- a/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
+++ b/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
@@ -270,6 +270,22 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for wallet 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"wallet\\",
+  entitlements: {\\"com.apple.developer.payment-pass-provisioning\\":true},
+});"
+`;
+
+exports[`getTemplateConfig should return a valid template for wallet-ui 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"wallet-ui\\",
+  entitlements: {\\"com.apple.developer.payment-pass-provisioning\\":true},
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for watch 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({

--- a/packages/create-target/src/__tests__/createAsync.test.ts
+++ b/packages/create-target/src/__tests__/createAsync.test.ts
@@ -37,6 +37,8 @@ const ALL_TARGET_TYPES = [
   "print-service",
   "smart-card",
   "authentication-services",
+  "wallet",
+  "wallet-ui",
 ];
 
 describe(getTemplateConfig, () => {

--- a/packages/create-target/src/createAsync.ts
+++ b/packages/create-target/src/createAsync.ts
@@ -257,4 +257,10 @@ const RECOMMENDED_ENTITLEMENTS: Record<Partial<ExtensionType>, any> = {
   "device-activity-monitor": {
     "com.apple.developer.family-controls": true,
   },
+  wallet: {
+    "com.apple.developer.payment-pass-provisioning": true,
+  },
+  "wallet-ui": {
+    "com.apple.developer.payment-pass-provisioning": true,
+  },
 };

--- a/packages/create-target/templates/wallet-ui/IssuerProvisioningAuthorizationViewController.swift
+++ b/packages/create-target/templates/wallet-ui/IssuerProvisioningAuthorizationViewController.swift
@@ -1,0 +1,35 @@
+import UIKit
+import PassKit
+
+/// UI In-App Provisioning Authorization Extension principal class.
+///
+/// Apple Wallet presents this view controller to authenticate the user when
+/// the non-UI extension reports `requiresAuthentication = true`. The
+/// `completionHandler` must be invoked with `.authorized` or `.canceled`
+/// once authentication finishes.
+///
+/// References:
+/// - https://developer.apple.com/documentation/passkit/pkissuerprovisioningextensionauthorizationproviding
+/// - https://applepaydemo.apple.com/in-app-provisioning-extensions
+class IssuerProvisioningAuthorizationViewController: UIViewController, PKIssuerProvisioningExtensionAuthorizationProviding {
+
+    var completionHandler: ((PKIssuerProvisioningExtensionAuthorizationResult) -> Void)?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        // TODO: Present the issuer's authentication UI here. Once the user
+        // authenticates (or cancels), invoke `completionHandler` with the
+        // appropriate `PKIssuerProvisioningExtensionAuthorizationResult`.
+    }
+
+    /// Convenience helper: call this from your authentication flow on success.
+    func reportAuthorized() {
+        completionHandler?(.authorized)
+    }
+
+    /// Convenience helper: call this from your authentication flow on cancel/failure.
+    func reportCanceled() {
+        completionHandler?(.canceled)
+    }
+}

--- a/packages/create-target/templates/wallet/IssuerProvisioningHandler.swift
+++ b/packages/create-target/templates/wallet/IssuerProvisioningHandler.swift
@@ -1,0 +1,44 @@
+import Foundation
+import PassKit
+
+/// Non-UI In-App Provisioning Extension principal class.
+///
+/// Apple Wallet uses this handler to discover which payment passes the issuer
+/// app can offer, whether authentication is required, and to provide the
+/// signed `PKAddPaymentPassRequest` that Wallet uses to provision the pass.
+///
+/// All non-deprecated methods of `PKIssuerProvisioningExtensionHandler` must
+/// be overridden without calling `super`.
+///
+/// References:
+/// - https://developer.apple.com/documentation/passkit/pkissuerprovisioningextensionhandler
+/// - https://applepaydemo.apple.com/in-app-provisioning-extensions
+class IssuerProvisioningHandler: PKIssuerProvisioningExtensionHandler {
+
+    override func status(completion: @escaping (PKIssuerProvisioningExtensionStatus) -> Void) {
+        let status = PKIssuerProvisioningExtensionStatus()
+        status.passEntriesAvailable = false
+        status.remotePassEntriesAvailable = false
+        status.requiresAuthentication = false
+        completion(status)
+    }
+
+    override func passEntries(completion: @escaping ([PKIssuerProvisioningExtensionPassEntry]) -> Void) {
+        completion([])
+    }
+
+    override func remotePassEntries(completion: @escaping ([PKIssuerProvisioningExtensionPassEntry]) -> Void) {
+        completion([])
+    }
+
+    override func generateAddPaymentPassRequestForPassEntryWithIdentifier(
+        _ identifier: String,
+        configuration: PKAddPaymentPassRequestConfiguration,
+        certificateChain certificates: [Data],
+        nonce: Data,
+        nonceSignature: Data,
+        completionHandler completion: @escaping (PKAddPaymentPassRequest?) -> Void
+    ) {
+        completion(nil)
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Motivation

Apple Wallet **In-App Provisioning Extensions** let users add an issuer's payment passes to Apple Wallet directly from Wallet's "+" menu (under "From Apps on Your iPhone"), without having to open the issuer app first. The feature is implemented as **two app extensions** working together:

- **Non-UI extension** — reports which passes are available, whether authentication is needed, and supplies the signed `PKAddPaymentPassRequest` to Wallet.
- **UI extension** — a `UIViewController` Wallet presents to authenticate the user when the non-UI extension reports `requiresAuthentication = true`.

We already implement these natively in the Brex `mobile` repo for the core app. With Continuous Native Generation via `@bacons/apple-targets`, we can scaffold and link these targets the same way we do widgets, share extensions, etc. — and once this lands here we can also push it upstream.

Reference: https://applepaydemo.apple.com/in-app-provisioning-extensions

# Execution

Followed the "Adding a new target type" checklist in `CLAUDE.md`. All edits are derived from the central `TARGET_REGISTRY` so the `ExtensionType` union, extension-point ID map, framework list, CLI list, and e2e coverage check pick the new types up automatically.

### `packages/apple-targets/src/target.ts`

Added two entries to `TARGET_REGISTRY`:

| key | extension point identifier | frameworks | app groups by default |
| --- | --- | --- | --- |
| `wallet` | `com.apple.PassKit.issuer-provisioning` | `PassKit` | yes |
| `wallet-ui` | `com.apple.PassKit.issuer-provisioning.authorization` | `PassKit`, `UIKit` | yes |

App Groups default to mirroring the main app because Wallet extensions are documented to share state with the containing issuer app via a shared App Group container (the host — Wallet — and the containing issuer app cannot communicate directly).

Added `Info.plist` cases in `getTargetInfoPlistForType()` that wire the principal classes to:
- `$(PRODUCT_MODULE_NAME).IssuerProvisioningHandler` (non-UI)
- `$(PRODUCT_MODULE_NAME).IssuerProvisioningAuthorizationViewController` (UI)

### `packages/apple-targets/src/configuration-list.ts`

Both new types fall through to `createDefaultConfigurationList()` — they don't need any of the special build-setting customizations (no asset catalog accent color, no watchOS SDK, etc.).

### `packages/create-target/templates/wallet/IssuerProvisioningHandler.swift`

`PKIssuerProvisioningExtensionHandler` subclass with all four non-deprecated methods overridden (Apple requires this — they must not call `super`). Returns "no passes available" by default; issuers fill in the methods.

### `packages/create-target/templates/wallet-ui/IssuerProvisioningAuthorizationViewController.swift`

`UIViewController` adopting `PKIssuerProvisioningExtensionAuthorizationProviding` with a `completionHandler` property and convenience helpers to report `.authorized` / `.canceled`.

### `packages/create-target/src/createAsync.ts`

Added `com.apple.developer.payment-pass-provisioning` as the recommended entitlement for both new targets in the scaffold output. (This is a **private** Apple entitlement — issuers still have to email `applepayentitlements@apple.com` to be allow-listed; the Swift will compile without it but Wallet won't surface the extensions until Apple grants the entitlement.)

### E2E + docs

- `e2e/fixture/targets/wallet/expo-target.config.json` and `wallet-ui/expo-target.config.json`.
- Added both rows to `e2e/__tests__/build.test.ts` `TARGET_REGISTRY` (`target` names `wallet` and `walletui`).
- Added both rows to the README "Supported types" table.
- `__tests__/createAsync.test.ts` snapshot list updated; new snapshots auto-generated.

# Test Plan

Ran from the workspace root with `bun`:

```
cd packages/apple-targets && bunx expo-module typecheck    # passes
cd packages/apple-targets && bunx jest                     # 8/8 pass
cd packages/create-target && bunx jest                     # 38/38 pass (incl. wallet, wallet-ui)
cd packages/apple-targets && bunx expo-module build        # builds clean
cd packages/create-target && bun run build                 # builds clean
```

Snapshot output for the new types looks like:

```js
// wallet
module.exports = config => ({
  type: "wallet",
  entitlements: {"com.apple.developer.payment-pass-provisioning":true},
});

// wallet-ui
module.exports = config => ({
  type: "wallet-ui",
  entitlements: {"com.apple.developer.payment-pass-provisioning":true},
});
```

The exhaustive `never` switch in `getConfigurationListBuildSettingsForType()` and the e2e meta-test ("registry covers all ExtensionType values") would have failed if either new type were missed — both pass.

The `xcodebuild` e2e suite requires macOS + Xcode, so it can't run in this Linux cloud agent. Once the branch is reviewed it can be exercised on the macOS CI runner that the repo already uses for `test:e2e` (the new `wallet` / `wallet-ui` cases will run automatically alongside the other 40+ targets).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff4de5e2-97dc-4a46-952f-6901d4890561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff4de5e2-97dc-4a46-952f-6901d4890561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

