### PR TITLE
Fix fallback require for AssetContents in nested @expo/cli paths

### DIFF
--- a/packages/apple-targets/src/icon/assetContents.ts
+++ b/packages/apple-targets/src/icon/assetContents.ts
@@ -1,0 +1,36 @@
+import { join } from "path";
+
+export type {
+  ContentsJson,
+  ContentsJsonImageIdiom,
+  ContentsJsonImage,
+} from "@expo/prebuild-config/build/plugins/icons/AssetContents";
+
+// The package location differs between Expo SDK versions: in newer setups it
+// may be nested under @expo/cli's own node_modules rather than at the project
+// root.  We try the canonical location first and fall back to the nested one.
+// The fallback path assumes this file is at:
+//   <project>/node_modules/@bacons/apple-targets/build/icon/
+// so four levels up reaches <project>/node_modules/, then into @expo/cli.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const _assetContents = (() => {
+  const pkg = "@expo/prebuild-config/build/plugins/icons/AssetContents";
+  try {
+    return require(pkg);
+  } catch (_primaryError) {
+    const fallbackPath = join(
+      __dirname,
+      "../../../../@expo/cli/node_modules/@expo/prebuild-config/build/plugins/icons/AssetContents.js",
+    );
+    try {
+      return require(fallbackPath);
+    } catch (_fallbackError) {
+      throw new Error(
+        `Could not load AssetContents from either "${pkg}" or the fallback path "${fallbackPath}". ` +
+          `Ensure @expo/prebuild-config is installed.`,
+      );
+    }
+  }
+})() as typeof import("@expo/prebuild-config/build/plugins/icons/AssetContents");
+
+export const { writeContentsJsonAsync } = _assetContents;

--- a/packages/apple-targets/src/icon/with-image-asset.ts
+++ b/packages/apple-targets/src/icon/with-image-asset.ts
@@ -1,11 +1,11 @@
 import { ConfigPlugin, withDangerousMod } from "expo/config-plugins";
 import { generateImageAsync } from "@expo/image-utils";
-import {
+import type {
   ContentsJson,
   ContentsJsonImageIdiom,
   ContentsJsonImage,
-  writeContentsJsonAsync,
-} from "@expo/prebuild-config/build/plugins/icons/AssetContents";
+} from "./assetContents";
+import { writeContentsJsonAsync } from "./assetContents";
 import * as fs from "fs";
 import path, { join } from "path";
 

--- a/packages/apple-targets/src/icon/with-ios-icon.ts
+++ b/packages/apple-targets/src/icon/with-ios-icon.ts
@@ -1,10 +1,10 @@
 import { ConfigPlugin, withDangerousMod } from "expo/config-plugins";
 import { generateImageAsync } from "@expo/image-utils";
-import {
+import type {
   ContentsJson,
   ContentsJsonImageIdiom,
-  writeContentsJsonAsync,
-} from "@expo/prebuild-config/build/plugins/icons/AssetContents";
+} from "./assetContents";
+import { writeContentsJsonAsync } from "./assetContents";
 import * as fs from "fs";
 import { join } from "path";
 


### PR DESCRIPTION
This pull request improves compatibility with different Expo SDK setups by refactoring how the `writeContentsJsonAsync` utility and related types are imported for icon asset generation. The main change is the introduction of a new module that dynamically resolves the correct import path for `AssetContents`, ensuring the code works regardless of the package's location in the `node_modules` hierarchy.

**Improved asset utility import and compatibility:**

* Added a new `assetContents` module (`assetContents.ts`) that attempts to require `@expo/prebuild-config/build/plugins/icons/AssetContents` from both the canonical and fallback paths, throwing a helpful error if neither is found. This ensures compatibility with different Expo SDK versions and project setups.
* Updated `with-image-asset.ts` and `with-ios-icon.ts` to import types and the `writeContentsJsonAsync` function from the new `assetContents` module instead of importing directly from `@expo/prebuild-config`. This centralizes and simplifies asset utility imports. [[1]](diffhunk://#diff-8d192fcd136d197eaf22fda7b15cbc05837d20aab18dd0449e3de507b50b9b2eL3-R8) [[2]](diffhunk://#diff-fd447d95feef3a0ab1add8017ac9a3148f44e58fc8a6253abe129b5f65f87474L3-R7)