### PR TITLE
fix: declare @expo/prebuild-config as a runtime dependency (fixes SDK 56)

### DIFF
--- a/packages/apple-targets/package.json
+++ b/packages/apple-targets/package.json
@@ -122,6 +122,7 @@
   "license": "MIT",
   "dependencies": {
     "@bacons/xcode": "1.0.0-alpha.32",
+    "@expo/prebuild-config": "~55.0.6",
     "@react-native/normalize-colors": "^0.79.2",
     "glob": "^10.4.2",
     "debug": "^4.3.4"
@@ -133,7 +134,6 @@
     "@expo/image-utils": "^0.8.8",
     "@expo/npm-proofread": "^1.0.1",
     "@expo/plist": "^0.4.8",
-    "@expo/prebuild-config": "~55.0.6",
     "@types/debug": "^4.1.7",
     "@types/glob": "^8.1.0",
     "chalk": "^4.0.0",


### PR DESCRIPTION
## Problem

`@expo/prebuild-config` is imported at **runtime** by the config plugin:

- `src/with-widget.ts` — `import { writeContentsJsonAsync } from "@expo/prebuild-config/build/plugins/icons/AssetContents"`
- `src/icon/with-ios-icon.ts`, `src/icon/with-image-asset.ts`, `src/colorset/with-ios-colorset.ts`

…but it was only listed under `devDependencies`. It previously resolved because `@expo/prebuild-config` was hoisted to the project's top-level `node_modules` via the consumer's `expo` install.

As of **Expo SDK 56**, `@expo/prebuild-config` is nested under `@expo/cli/node_modules` and is no longer hoisted to the top level. The bare `require("@expo/prebuild-config/build/plugins/icons/AssetContents")` then throws:

```
PluginError: Cannot find module '@expo/prebuild-config/build/plugins/icons/AssetContents'
```

This breaks `npx expo config` / prebuild for any project using `@bacons/apple-targets` on SDK 56.

## Fix

Move `@expo/prebuild-config` from `devDependencies` to `dependencies` so the plugin is self-contained and doesn't rely on hoisting.

## Notes

- Kept the existing `~55.0.6` range (matches the repo's current SDK 55 line); widen when bumping to SDK 56.
- `@expo/config-plugins` and `@expo/plist` are also imported at runtime and still only in `devDependencies` — they happen to still resolve, but may warrant the same treatment for robustness. Left out here to keep the fix focused on the reported breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)