### PR TITLE
fix: make Xcode target updates idempotent when prebuilding over an existing project

### DIFF
--- a/packages/apple-targets/src/__tests__/isNativeTargetOfType.test.ts
+++ b/packages/apple-targets/src/__tests__/isNativeTargetOfType.test.ts
@@ -1,0 +1,86 @@
+import type { PBXNativeTarget } from "@bacons/xcode";
+
+import { isNativeTargetOfType } from "../target";
+
+function mockTarget({
+  productType,
+  productName,
+  infoPlist = {},
+  buildSettings = {},
+}: {
+  productType: string;
+  productName: string;
+  infoPlist?: Record<string, any>;
+  buildSettings?: Record<string, any>;
+}): PBXNativeTarget {
+  return {
+    props: { productType, productName },
+    getDefaultConfiguration: () => ({
+      props: { buildSettings },
+      getInfoPlist: () => infoPlist,
+    }),
+    getDisplayName: () => productName,
+  } as unknown as PBXNativeTarget;
+}
+
+describe(isNativeTargetOfType, () => {
+  it("matches an ExtensionKit extension by EXExtensionPointIdentifier", () => {
+    const target = mockTarget({
+      productType: "com.apple.product-type.extensionkit-extension",
+      productName: "myintents",
+      infoPlist: {
+        EXAppExtensionAttributes: {
+          EXExtensionPointIdentifier: "com.apple.appintents-extension",
+        },
+      },
+    });
+
+    expect(isNativeTargetOfType(target, "app-intent")).toBe(true);
+  });
+
+  it("does not match an ExtensionKit extension against an NSExtension-based type", () => {
+    const target = mockTarget({
+      productType: "com.apple.product-type.extensionkit-extension",
+      productName: "myintents",
+      infoPlist: {
+        EXAppExtensionAttributes: {
+          EXExtensionPointIdentifier: "com.apple.appintents-extension",
+        },
+      },
+    });
+
+    expect(isNativeTargetOfType(target, "widget")).toBe(false);
+  });
+
+  it("falls back to product name matching when an ExtensionKit extension has no extension point identifier", () => {
+    const target = mockTarget({
+      productType: "com.apple.product-type.extensionkit-extension",
+      productName: "app-intent",
+    });
+
+    expect(isNativeTargetOfType(target, "app-intent")).toBe(true);
+  });
+
+  it("does not match an ExtensionKit extension without identifier or matching name", () => {
+    const target = mockTarget({
+      productType: "com.apple.product-type.extensionkit-extension",
+      productName: "myintents",
+    });
+
+    expect(isNativeTargetOfType(target, "app-intent")).toBe(false);
+  });
+
+  it("still matches a classic app extension by NSExtensionPointIdentifier", () => {
+    const target = mockTarget({
+      productType: "com.apple.product-type.app-extension",
+      productName: "mywidget",
+      infoPlist: {
+        NSExtension: {
+          NSExtensionPointIdentifier: "com.apple.widgetkit-extension",
+        },
+      },
+    });
+
+    expect(isNativeTargetOfType(target, "widget")).toBe(true);
+  });
+});

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -830,6 +830,34 @@ export function isNativeTargetOfType(
     return false;
   }
 
+  // ExtensionKit extensions (e.g. App Intents) declare
+  // `EXAppExtensionAttributes.EXExtensionPointIdentifier` in their Info.plist
+  // instead of `NSExtension.NSExtensionPointIdentifier`. Without this branch
+  // they can never be matched, so re-running prebuild creates a duplicate
+  // target on every run.
+  if (
+    target.props.productType ===
+    "com.apple.product-type.extensionkit-extension"
+  ) {
+    if (
+      productTypeForType(type) !==
+      "com.apple.product-type.extensionkit-extension"
+    ) {
+      return false;
+    }
+    const infoPlist = target.getDefaultConfiguration().getInfoPlist();
+    const identifier = (
+      infoPlist.EXAppExtensionAttributes as
+        | { EXExtensionPointIdentifier?: string }
+        | undefined
+    )?.EXExtensionPointIdentifier;
+    if (identifier) {
+      return KNOWN_EXTENSION_POINT_IDENTIFIERS[identifier] === type;
+    }
+    // Fall back to name matching when no extension point identifier is set.
+    return target.props.productName === type;
+  }
+
   if (target.props.productType !== "com.apple.product-type.app-extension") {
     return false;
   }

--- a/packages/apple-targets/src/with-xcode-changes.ts
+++ b/packages/apple-targets/src/with-xcode-changes.ts
@@ -100,9 +100,13 @@ async function applyXcodeChanges(
 
   const productName = props.productName;
 
-  let targetToUpdate: PBXNativeTarget | undefined =
-    targets.find((target) => target.props.productName === productName) ??
-    targets[0];
+  // Only update a target whose product name matches. Falling back to the
+  // first target of the same type would destructively rewrite an unrelated
+  // target (e.g. another widget owned by a different config plugin) when the
+  // product name doesn't match.
+  let targetToUpdate: PBXNativeTarget | undefined = targets.find(
+    (target) => target.props.productName === productName,
+  );
 
   if (targetToUpdate) {
     warnOnce(
@@ -296,26 +300,28 @@ async function applyXcodeChanges(
   }
 
   if (targetToUpdate) {
-    // Remove existing build phases
-    targetToUpdate.props.buildConfigurationList.props.buildConfigurations.forEach(
-      (config) => {
+    // Create and assign the new configuration list FIRST —
+    // createConfigurationListForType() calls getMainAppTarget(), which
+    // iterates all targets and reads their build configurations. Removing the
+    // old list before that traversal leaves this target with a dangling
+    // configuration list and crashes (e.g. for watch targets).
+    const oldConfigList = targetToUpdate.props.buildConfigurationList;
+    targetToUpdate.props.buildConfigurationList =
+      createConfigurationListForType(project, props);
+
+    // Now clean up the old configuration list.
+    if (oldConfigList) {
+      oldConfigList.props.buildConfigurations.forEach((config) => {
         config.getReferrers().forEach((ref) => {
           ref.removeReference(config.uuid);
         });
         config.removeFromProject();
-      },
-    );
-    // Remove existing build configuration list
-    targetToUpdate.props.buildConfigurationList
-      .getReferrers()
-      .forEach((ref) => {
-        ref.removeReference(targetToUpdate!.props.buildConfigurationList.uuid);
       });
-    targetToUpdate.props.buildConfigurationList.removeFromProject();
-
-    // Create new build phases
-    targetToUpdate.props.buildConfigurationList =
-      createConfigurationListForType(project, props);
+      oldConfigList.getReferrers().forEach((ref) => {
+        ref.removeReference(oldConfigList.uuid);
+      });
+      oldConfigList.removeFromProject();
+    }
   } else {
     const productType = productTypeForType(props.type);
     const isExtension = productType === "com.apple.product-type.app-extension";
@@ -426,7 +432,14 @@ async function applyXcodeChanges(
       ) ?? mainAppTarget
     : mainAppTarget;
 
-  dependencyParent.addDependency(targetToUpdate);
+  // Avoid accumulating duplicate PBXTargetDependency entries when prebuild is
+  // re-run over an existing project.
+  const hasDependency = dependencyParent.props.dependencies?.some(
+    (dep) => dep.props.target === targetToUpdate,
+  );
+  if (!hasDependency) {
+    dependencyParent.addDependency(targetToUpdate);
+  }
 
   const assetsDir = path.join(magicCwd, "assets");
 
@@ -507,7 +520,11 @@ async function applyXcodeChanges(
         target: mainAppTarget,
       });
     exceptionSet.props.membershipExceptions = sharedAssets.sort();
-    syncRootGroup.props.exceptions.push(exceptionSet);
+    // Only push newly created exception sets — re-pushing an existing one
+    // duplicates it in the exceptions array on every prebuild run.
+    if (!existingExceptionSet) {
+      syncRootGroup.props.exceptions.push(exceptionSet);
+    }
   } else {
     // Remove the exception set if there are no shared assets.
     existingExceptionSet?.removeFromProject();


### PR DESCRIPTION
## Problem

`applyXcodeChanges` works correctly on a fresh `prebuild --clean`, but the *update-existing-target* path (running `npx expo prebuild` over a committed/existing `ios/` directory, which also happens in CNG-less and bare workflows) has several bugs. We've been running these fixes via `patch-package` in production for a few months ([Unwindly](https://apps.apple.com/app/id6743421907), iOS app + watch app + watch widget + a foreign widget target in the same project).

### 1. ExtensionKit extensions are invisible to target detection → duplicated every run
`isNativeTargetOfType()` only recognizes `app-extension` products via `NSExtension.NSExtensionPointIdentifier`. ExtensionKit extensions (`com.apple.product-type.extensionkit-extension`, e.g. the `app-intent` type this plugin itself creates) declare `EXAppExtensionAttributes.EXExtensionPointIdentifier` instead — exactly what `getTargetInfoPlistForType("app-intent")` writes. They hard-failed the `!== app-extension` check, so on every re-run the plugin thought the target didn't exist and created a duplicate.

**Fix:** match ExtensionKit targets via `EXAppExtensionAttributes.EXExtensionPointIdentifier` against `KNOWN_EXTENSION_POINT_IDENTIFIERS` (same approach as the existing `NSExtension` path), with a product-name fallback when no identifier is present. Covered by new unit tests (2 of which fail on `main`).

### 2. `?? targets[0]` fallback destructively rewrites unrelated targets
When the product-name lookup misses, the code fell back to the first target of the same detected type and "updated" it — tearing out its build configuration list and rewriting its phases. With multiple extensions in one project (e.g. a second widget owned by a different config plugin) this silently clobbers a target the plugin doesn't own.

**Fix:** only update on an exact product-name match; otherwise create a new target (visible and recoverable in a diff, instead of silent corruption).

### 3. Crash when updating an existing watch target
The update path removed the target's old `XCConfigurationList` (and its `XCBuildConfiguration`s) **before** calling `createConfigurationListForType()`. For watch targets that helper calls `getMainAppTarget()`, which iterates all targets and reads their default configuration — at that moment the target being updated has a dangling configuration list, and the traversal crashes. Never fires on a fresh prebuild; fires reliably on the second one.

**Fix:** create and assign the new configuration list first, then garbage-collect the old one.

### 4. Duplicate `PBXTargetDependency` entries accumulate
`dependencyParent.addDependency(targetToUpdate)` runs unconditionally, appending a new dependency entry on every prebuild. Related symptom reported in #175 ("Duplicate/stale watch embed entries").

**Fix:** skip when a dependency on that target already exists.

### 5. Shared-asset exception set re-pushed on every run
The `_shared` handling find-or-creates a `PBXFileSystemSynchronizedBuildFileExceptionSet` but pushed it into `syncRootGroup.props.exceptions` unconditionally — so a *found* set got pushed again on every run, duplicating entries in the exceptions array.

**Fix:** only push newly created sets.

## Testing

- `tsc --noEmit` clean
- All existing unit tests pass; added `isNativeTargetOfType.test.ts` (5 tests, 2 fail without fix 1)
- All five fixes battle-tested for months via `patch-package` against 4.0.6 in a project with `watch` + `watch-widget` + foreign widget targets, where prebuild re-runs over a committed `ios/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)