### PR TITLE
fix: match existing ExtensionKit (app-intent) targets in isNativeTargetOfType

### DIFF
--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -805,6 +805,20 @@ export function isNativeTargetOfType(
     return true;
   }
 
+  // ExtensionKit extensions (app-intent) use a distinct product type and
+  // declare EXAppExtensionAttributes rather than NSExtension in their
+  // Info.plist, so neither the app-extension productType check nor the
+  // NSExtensionPointIdentifier lookup below can ever match them. Without
+  // this branch, every non-clean prebuild appends a duplicate target.
+  // Callers disambiguate multiple matches by productName.
+  if (
+    type === "app-intent" &&
+    target.props.productType ===
+      "com.apple.product-type.extensionkit-extension"
+  ) {
+    return true;
+  }
+
   const hasWatchOS =
     "WATCHOS_DEPLOYMENT_TARGET" in
     target.getDefaultConfiguration().props.buildSettings;


### PR DESCRIPTION
Fixes #202.

`isNativeTargetOfType` could never return `true` for `app-intent` targets: they are ExtensionKit extensions (`com.apple.product-type.extensionkit-extension`), so the `app-extension` productType guard rejects them, and their Info.plist carries `EXAppExtensionAttributes` rather than `NSExtension`, so the extension-point lookup can't identify them either. As a result, `applyXcodeChanges` treated the existing target as absent on every non-clean prebuild and appended a fresh copy — Xcode then emits the `.appex` twice and the build fails with a duplicate-output error.

This adds an explicit ExtensionKit branch mirroring the existing `watch`/`clip` special cases. Name disambiguation is unchanged (callers select by `productName`).

**Tested:** on a project with an `app-intent` target plus widget and DeviceActivity targets — `prebuild --clean` followed by two non-clean prebuilds holds at exactly one target of each type, and the app-intent target now logs `Target "…" already exists, updating instead of creating a new one` like the others. Previously each non-clean run appended one duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
