### PR TITLE
feat(targets): support ESM and TypeScript expo-target.config files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -66,6 +66,7 @@
       "version": "4.0.7",
       "dependencies": {
         "@bacons/xcode": "1.0.0-alpha.32",
+        "@expo/require-utils": "^55.0.4",
         "@react-native/normalize-colors": "^0.79.2",
         "debug": "^4.3.4",
         "glob": "^10.4.2",

--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -57,7 +57,7 @@ The CLI auto-detects your installed agents and copies the skill into their skill
 
 ## Target config
 
-The target config can be a `expo-target.config.js`, or `expo-target.config.json` file.
+The target config can be `expo-target.config.json`, `expo-target.config.js` (CommonJS or ESM), `expo-target.config.cjs`, `expo-target.config.mjs`, or `expo-target.config.ts` (also `.cts` / `.mts`). TypeScript and ESM files are evaluated through the same loader Expo uses for `app.config.ts`. If multiple files exist in the same target directory, the highest-priority one wins (`ts` → `mts` → `cts` → `mjs` → `js` → `cjs` → `json`) and the others are ignored with a warning.
 
 This file can have the following properties:
 

--- a/packages/apple-targets/package.json
+++ b/packages/apple-targets/package.json
@@ -123,6 +123,7 @@
   "dependencies": {
     "@bacons/xcode": "1.0.0-alpha.32",
     "@expo/prebuild-config": "~55.0.6",
+    "@expo/require-utils": "^55.0.4",
     "@react-native/normalize-colors": "^0.79.2",
     "glob": "^10.4.2",
     "debug": "^4.3.4"

--- a/packages/apple-targets/src/config-plugin.ts
+++ b/packages/apple-targets/src/config-plugin.ts
@@ -1,4 +1,5 @@
 import { ConfigPlugin } from "expo/config-plugins";
+import { loadModuleSync } from "@expo/require-utils";
 import { globSync } from "glob";
 import path from "path";
 import chalk from "chalk";
@@ -8,6 +9,35 @@ import { withPodTargetExtension } from "./with-pod-target-extension";
 import withWidget from "./with-widget";
 import { withXcodeProjectBetaBaseMod } from "./with-bacons-xcode";
 import { warnOnce } from "./util";
+
+// Highest-to-lowest priority. Used both for globbing and for the deterministic
+// pick when multiple config files exist in the same target directory.
+const TARGET_CONFIG_EXTENSIONS = [
+  "ts",
+  "mts",
+  "cts",
+  "mjs",
+  "js",
+  "cjs",
+  "json",
+] as const;
+
+function loadTargetConfig(configPath: string): unknown {
+  if (configPath.endsWith(".json")) {
+    return require(configPath);
+  }
+  const mod = loadModuleSync(configPath);
+  // Unwrap an ESM default export (e.g. `export default { ... }`).
+  if (
+    mod &&
+    typeof mod === "object" &&
+    (mod as { __esModule?: boolean }).__esModule &&
+    "default" in mod
+  ) {
+    return (mod as { default: unknown }).default;
+  }
+  return mod;
+}
 
 export const withTargetsDir: ConfigPlugin<
   {
@@ -35,31 +65,71 @@ export const withTargetsDir: ConfigPlugin<
     );
   }
 
-  const targets = globSync(`${root}/${match}/expo-target.config.@(json|js)`, {
-    // const targets = globSync(`./targets/action/expo-target.config.@(json|js)`, {
-    cwd: projectRoot,
-    absolute: true,
-  });
+  const targets = globSync(
+    `${root}/${match}/expo-target.config.@(${TARGET_CONFIG_EXTENSIONS.join("|")})`,
+    {
+      cwd: projectRoot,
+      absolute: true,
+    },
+  );
 
-  targets.forEach((configPath) => {
-    const targetConfig = require(configPath);
-    let evaluatedTargetConfigObject = targetConfig;
+  // Multiple config files in the same target directory would silently register
+  // the target twice — pick the highest-priority extension and warn.
+  const configsByDirectory = new Map<string, string[]>();
+  for (const configPath of targets) {
+    const dir = path.dirname(configPath);
+    const list = configsByDirectory.get(dir);
+    if (list) list.push(configPath);
+    else configsByDirectory.set(dir, [configPath]);
+  }
+
+  const resolvedTargets: string[] = [];
+  for (const [dir, configs] of configsByDirectory) {
+    const sorted = [...configs].sort(
+      (a, b) =>
+        TARGET_CONFIG_EXTENSIONS.indexOf(
+          path.extname(a).slice(1) as (typeof TARGET_CONFIG_EXTENSIONS)[number],
+        ) -
+        TARGET_CONFIG_EXTENSIONS.indexOf(
+          path.extname(b).slice(1) as (typeof TARGET_CONFIG_EXTENSIONS)[number],
+        ),
+    );
+    if (sorted.length > 1) {
+      const ignored = sorted
+        .slice(1)
+        .map((p) => path.basename(p))
+        .join(", ");
+      warnOnce(
+        chalk`{yellow [bacons/apple-targets]} Multiple {cyan expo-target.config} files in {cyan ${path.relative(projectRoot, dir)}}. Using {cyan ${path.basename(sorted[0])}} and ignoring: {cyan ${ignored}}`,
+      );
+    }
+    resolvedTargets.push(sorted[0]);
+  }
+
+  resolvedTargets.forEach((configPath) => {
+    const targetConfig = loadTargetConfig(configPath);
+    let evaluatedTargetConfigObject: unknown = targetConfig;
     // If it's a function, evaluate it
     if (typeof targetConfig === "function") {
-      evaluatedTargetConfigObject = targetConfig(config);
+      evaluatedTargetConfigObject = (targetConfig as ConfigFunction)(config);
 
-      if (typeof evaluatedTargetConfigObject !== "object") {
+      if (
+        !evaluatedTargetConfigObject ||
+        typeof evaluatedTargetConfigObject !== "object"
+      ) {
         throw new Error(
           `Expected target config function to return an object, but got ${typeof evaluatedTargetConfigObject}`,
         );
       }
-    } else if (typeof targetConfig !== "object") {
+    } else if (!targetConfig || typeof targetConfig !== "object") {
       throw new Error(
         `Expected target config to be an object or function that returns an object, but got ${typeof targetConfig}`,
       );
     }
 
-    if (!evaluatedTargetConfigObject.type) {
+    const resolvedConfig = evaluatedTargetConfigObject as Config;
+
+    if (!resolvedConfig.type) {
       throw new Error(
         `Expected target config to have a 'type' property denoting the type of target it is, e.g. 'widget'`,
       );
@@ -67,7 +137,7 @@ export const withTargetsDir: ConfigPlugin<
 
     config = withWidget(config, {
       appleTeamId,
-      ...evaluatedTargetConfigObject,
+      ...resolvedConfig,
       directory: path.relative(projectRoot, path.dirname(configPath)),
       configPath,
     });

--- a/packages/apple-targets/src/config-plugin.ts
+++ b/packages/apple-targets/src/config-plugin.ts
@@ -22,11 +22,35 @@ const TARGET_CONFIG_EXTENSIONS = [
   "json",
 ] as const;
 
+// `@expo/require-utils` rewrites a TypeScript config's filename to its JS
+// equivalent (`.ts` → `.js`, `.mts` → `.mjs`, `.cts` → `.cjs`) before compiling
+// it via `Module._compile`, and registers BOTH the real path and that virtual
+// path in `require.cache`. Tools like `@expo/fingerprint` snapshot `require.cache`
+// to discover loaded plugin sources and then try to read them from disk — the
+// virtual path doesn't exist, causing `ENOENT: ... expo-target.config.js` during
+// `eas build`. Mirror the loader's mapping so we can drop the virtual entry.
+const TS_TO_JS_EXTENSION: Record<string, string> = {
+  ".ts": ".js",
+  ".mts": ".mjs",
+  ".cts": ".cjs",
+};
+
 function loadTargetConfig(configPath: string): unknown {
   if (configPath.endsWith(".json")) {
     return require(configPath);
   }
   const mod = loadModuleSync(configPath);
+
+  const ext = path.extname(configPath);
+  const virtualExt = TS_TO_JS_EXTENSION[ext];
+  if (virtualExt) {
+    const virtualPath =
+      configPath.slice(0, configPath.length - ext.length) + virtualExt;
+    if (require.cache[virtualPath]) {
+      delete require.cache[virtualPath];
+    }
+  }
+
   // Unwrap an ESM default export (e.g. `export default { ... }`).
   if (
     mod &&


### PR DESCRIPTION
> Recreates #190 (the original author account is no longer accessible), rebased onto current `main` so it merges cleanly.

## Summary

- `expo-target.config` now accepts `.ts`, `.mts`, `.cts`, `.mjs`, and `.cjs` in addition to the existing `.js` and `.json` ([README](packages/apple-targets/README.md) updated).
- TypeScript / ESM files are loaded via `@expo/require-utils`'s `loadModuleSync` — the same loader Expo uses for `app.config.ts` — so no extra runtime config is needed. An ESM `default` export is unwrapped automatically.
- If multiple config files coexist in the same target directory, the highest-priority extension wins (`ts` → `mts` → `cts` → `mjs` → `js` → `cjs` → `json`) and the rest are skipped with a warning, instead of silently registering the target twice.

## Examples

`expo-target.config.ts`:
```ts
import type { ConfigFunction } from "@bacons/apple-targets/app.plugin";

const config: ConfigFunction = () => ({
  type: "widget",
  icon: "../assets/icon.png",
});

export default config;
```

`expo-target.config.mjs`:
```js
export default {
  type: "widget",
  icon: "../assets/icon.png",
};
```

## Implementation notes

- Adds `@expo/require-utils` as a direct dependency. It's already pulled in transitively via `@expo/config` / `@expo/config-plugins`, but declaring it directly avoids relying on a transitive resolution.
- Loader logic lives in a new `loadTargetConfig` helper at the top of [packages/apple-targets/src/config-plugin.ts](packages/apple-targets/src/config-plugin.ts):
  - `.json` → `require()` (unchanged)
  - everything else → `loadModuleSync(...)`, then unwrap an ESM `default` if `__esModule` is set
- Glob expanded to `expo-target.config.@(ts|mts|cts|mjs|js|cjs|json)`.
- Dedup is a single pass that groups by `path.dirname`, sorts by extension priority, and emits one `warnOnce` per directory with extras.
- Includes the follow-up fix from #190: `loadModuleSync` registers TS configs in `require.cache` under a virtual path with the extension rewritten to `.js`, which `@expo/fingerprint` then tries to read from disk during `eas build` (`ENOENT`). The virtual cache entry is deleted after loading; the real `.ts` entry stays so fingerprint still picks up the actual config file.

## Test plan

- [x] `bunx tsc --noEmit` in `packages/apple-targets`
- [x] `bunx jest --no-watch` in `packages/apple-targets` (21/21 pass — existing tests; loader is new code path)
- [ ] Manual: create `targets/widget/expo-target.config.ts` with `export default` → run `expo prebuild -p ios --clean` → confirm widget target is generated
- [ ] Manual: same with `expo-target.config.mjs`
- [ ] Manual: have both `.ts` and `.js` in the same target directory → confirm `.ts` wins and a warning is printed
- [ ] e2e suite (requires macOS + Xcode) — existing fixtures use `.json` / `.js` so they exercise the unchanged paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
