### PR TITLE
Fix crash when updating an existing target on incremental prebuild

### DIFF
--- a/packages/apple-targets/src/with-xcode-changes.ts
+++ b/packages/apple-targets/src/with-xcode-changes.ts
@@ -297,7 +297,9 @@ async function applyXcodeChanges(
 
   if (targetToUpdate) {
     // Remove existing build phases
-    targetToUpdate.props.buildConfigurationList.props.buildConfigurations.forEach(
+    const existingConfigurationList =
+      targetToUpdate.props.buildConfigurationList;
+    [...existingConfigurationList.props.buildConfigurations].forEach(
       (config) => {
         config.getReferrers().forEach((ref) => {
           ref.removeReference(config.uuid);
@@ -306,12 +308,10 @@ async function applyXcodeChanges(
       },
     );
     // Remove existing build configuration list
-    targetToUpdate.props.buildConfigurationList
-      .getReferrers()
-      .forEach((ref) => {
-        ref.removeReference(targetToUpdate!.props.buildConfigurationList.uuid);
-      });
-    targetToUpdate.props.buildConfigurationList.removeFromProject();
+    existingConfigurationList.getReferrers().forEach((ref) => {
+      ref.removeReference(existingConfigurationList.uuid);
+    });
+    existingConfigurationList.removeFromProject();
 
     // Create new build phases
     targetToUpdate.props.buildConfigurationList =


### PR DESCRIPTION
Fixes #201

Every non-clean `expo prebuild -p ios` crashes when a target already exists in the project:

    Target "AcmeWidget" already exists, updating instead of creating a new one
    ✖ Prebuild failed
    TypeError: [ios.xcodeProjectBeta2]: withIosXcodeProjectBeta2BaseMod: Cannot read properties of undefined (reading 'removeFromProject')

The teardown in `applyXcodeChanges` removes the target's reference to its build configuration list, then re-resolves `targetToUpdate.props.buildConfigurationList` - the edge it just severed - so the getter returns undefined and `removeFromProject()` throws (`removeReference` sets the matching object prop to `undefined` in `@bacons/xcode`).

There is a second, silent bug in the same block: the config loop iterates `props.buildConfigurations` while `removeReference` splices that same array. With the usual Debug + Release pair, the loop ends after Debug and Release is left behind as an orphaned `XCBuildConfiguration` in the pbxproj.

Fix: resolve the list into a local before the teardown and iterate a snapshot of the configurations. Both loops now complete and the final `removeFromProject()` runs on a live object.

Tested against a project with a committed `ios/` and an existing keyboard-extension target: before the change incremental prebuild reproduces the crash 100%, after it completes through the update path and `xcodebuild -list` shows all targets intact. Clean prebuild unaffected (create path untouched).