### PR TITLE
feat(targets): add device-activity-report target type

### DIFF
--- a/docs/xcode-target-discovery.md
+++ b/docs/xcode-target-discovery.md
@@ -151,6 +151,7 @@ The project's `ExtensionType` in `packages/apple-targets/src/target.ts` maps to 
 | `network-dns-proxy` | `com.apple.networkextension.dns-proxy` | app-extension |
 | `network-filter-data` | `com.apple.networkextension.filter-data` | app-extension |
 | `app-intent` | `com.apple.appintents-extension` | extensionkit-extension |
+| `device-activity-report` | `com.apple.deviceactivityui.report-extension` | extensionkit-extension |
 | `clip` | _(none — uses NSAppClip)_ | application.on-demand-install-capable |
 | `watch` | _(none — standalone app)_ | application |
 

--- a/packages/apple-targets/README.md
+++ b/packages/apple-targets/README.md
@@ -352,6 +352,7 @@ Ideally, this would be generated automatically based on a fully qualified Xcode 
 | credentials-provider      | Credentials Provider Extension     |
 | account-auth              | Account Authentication Extension   |
 | device-activity-monitor   | Device Activity Monitor Extension  |
+| device-activity-report    | Device Activity Report Extension   |
 | keyboard                  | Custom Keyboard Extension          |
 | matter                    | Matter Device Setup Extension      |
 | network-packet-tunnel     | Packet Tunnel Network Extension    |

--- a/packages/apple-targets/src/configuration-list.ts
+++ b/packages/apple-targets/src/configuration-list.ts
@@ -858,6 +858,7 @@ function getConfigurationListBuildSettingsForType(
     case "bg-download":
     case "credentials-provider":
     case "device-activity-monitor":
+    case "device-activity-report":
     case "intent":
     case "intent-ui":
     case "location-push":

--- a/packages/apple-targets/src/target.ts
+++ b/packages/apple-targets/src/target.ts
@@ -143,6 +143,12 @@ export const TARGET_REGISTRY = {
     frameworks: ["DeviceActivity"],
     displayName: "Device Activity Monitor",
   },
+  "device-activity-report": {
+    extensionPointIdentifier: "com.apple.deviceactivityui.report-extension",
+    productType: "com.apple.product-type.extensionkit-extension",
+    frameworks: ["DeviceActivity", "SwiftUI"],
+    displayName: "Device Activity Report",
+  },
   "network-packet-tunnel": {
     extensionPointIdentifier: "com.apple.networkextension.packet-tunnel",
     needsEmbeddedSwift: true,
@@ -728,6 +734,12 @@ export function getTargetInfoPlistForType(type: ExtensionType) {
           NSExtensionPointIdentifier,
           NSExtensionPrincipalClass:
             "$(PRODUCT_MODULE_NAME).DeviceActivityMonitorExtension",
+        },
+      };
+    case "device-activity-report":
+      return {
+        EXAppExtensionAttributes: {
+          EXExtensionPointIdentifier: NSExtensionPointIdentifier,
         },
       };
     case "print-service":

--- a/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
+++ b/packages/create-target/src/__tests__/__snapshots__/createAsync.test.ts.snap
@@ -99,6 +99,14 @@ module.exports = config => ({
 });"
 `;
 
+exports[`getTemplateConfig should return a valid template for device-activity-report 1`] = `
+"/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
+module.exports = config => ({
+  type: \\"device-activity-report\\",
+  entitlements: {\\"com.apple.developer.family-controls\\":true},
+});"
+`;
+
 exports[`getTemplateConfig should return a valid template for file-provider 1`] = `
 "/** @type {import('@bacons/apple-targets/app.plugin').ConfigFunction} */
 module.exports = config => ({

--- a/packages/create-target/src/__tests__/createAsync.test.ts
+++ b/packages/create-target/src/__tests__/createAsync.test.ts
@@ -20,6 +20,7 @@ const ALL_TARGET_TYPES = [
   "credentials-provider",
   "account-auth",
   "device-activity-monitor",
+  "device-activity-report",
   "file-provider",
   "broadcast-upload",
   "call-directory",

--- a/packages/create-target/src/createAsync.ts
+++ b/packages/create-target/src/createAsync.ts
@@ -257,6 +257,9 @@ const RECOMMENDED_ENTITLEMENTS: Record<Partial<ExtensionType>, any> = {
   "device-activity-monitor": {
     "com.apple.developer.family-controls": true,
   },
+  "device-activity-report": {
+    "com.apple.developer.family-controls": true,
+  },
   wallet: {
     "com.apple.developer.payment-pass-provisioning": true,
   },


### PR DESCRIPTION
Adds `device-activity-report` to the target registry.

## Why

`DeviceActivityReport` is the other half of Apple's Screen Time API. `device-activity-monitor`, already supported here, reacts to usage thresholds in the background; the report extension is what actually renders the usage data, as a SwiftUI scene the host app embeds through `DeviceActivityReport`. An app doing anything visible with Screen Time needs both.

Right now the monitor target is generated for you and the report target is not, so it has to be recreated by hand in Xcode after every `prebuild`, along with its entitlements and app group. That is the one step that stops the target folder from being the source of truth.

## What it takes

It is an ExtensionKit extension rather than a classic app extension, so it differs from `device-activity-monitor` in two ways and is otherwise identical:

- `productType: "com.apple.product-type.extensionkit-extension"`
- the extension point is declared through `EXAppExtensionAttributes` / `EXExtensionPointIdentifier`, the same shape `app-intent` already uses, rather than `NSExtension`

There is no `NSExtensionPrincipalClass`, because a report extension declares its scene with `@main`:

```swift
@main
struct ScreenTimeReport: DeviceActivityReportExtension {
    var body: some DeviceActivityReportScene {
        TotalActivityReport { totalActivity in
            TotalActivityView(totalActivity: totalActivity)
        }
    }
}
```

The extension point identifier is `com.apple.deviceactivityui.report-extension`. Note the `deviceactivityui`, which differs from the monitor's `com.apple.deviceactivity.monitor-extension`.

Build settings come from the default configuration list, alongside `device-activity-monitor`. I deliberately did not route it through `createAppIntentConfigurationList` even though that is the other ExtensionKit type, because that function hardcodes `IPHONEOS_DEPLOYMENT_TARGET: "17.0"` instead of honouring the configured deployment target.

Frameworks are `DeviceActivity` and `SwiftUI`.

## Changes

- `packages/apple-targets/src/target.ts`: registry entry, and the `EXAppExtensionAttributes` Info.plist case
- `packages/apple-targets/src/configuration-list.ts`: added to the default build settings group
- `packages/create-target/src/createAsync.ts`: recommended `com.apple.developer.family-controls` entitlement, matching the monitor extension
- `packages/create-target/src/__tests__/`: added to `ALL_TARGET_TYPES`, snapshot regenerated
- `packages/apple-targets/README.md` and `docs/xcode-target-discovery.md`: table entries

## Testing

- `expo-module typecheck` and `expo-module test` pass in both `packages/apple-targets` and `packages/create-target` (21 and 39 tests).
- I have been shipping this as a patch on top of 5.0.0 in a production Screen Time app for several months. The generated target builds, archives, passes App Store review and runs. This is the config it is generated from:

```ts
export default ((config) => ({
  type: "device-activity-report",
  displayName: "ScreenTimeReport",
  bundleIdentifier: ".ScreenTimeReport",
  entitlements: {
    "com.apple.developer.family-controls": true,
    "com.apple.security.application-groups": [APP_GROUP],
  },
})) satisfies ConfigFunction
```

I did not add an `e2e/fixture` target, since that needs a Swift template and an Xcode build, and `CONTRIBUTING.md` notes there are no continuous tests. Happy to add one, plus a `skills/apple-targets/device-activity-report.md` alongside the monitor's, if you would like this to land with the same coverage the monitor has.
